### PR TITLE
Add Activation Roadmap sections and refine community mobile UX

### DIFF
--- a/community/index.html
+++ b/community/index.html
@@ -333,6 +333,103 @@
         padding: 0.65rem 2rem;
         letter-spacing: 0.08em;
       }
+
+      /* Activation roadmap */
+      .activation-roadmap {
+        padding: 2.5rem 1.5rem 4rem;
+      }
+      .activation-roadmap-inner {
+        max-width: 1240px;
+        margin: 0 auto;
+      }
+      .activation-roadmap-head {
+        text-align: center;
+        margin-bottom: 2rem;
+      }
+      .activation-roadmap-kicker {
+        font-family: "DM Sans", sans-serif;
+        font-size: 0.74rem;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        color: rgba(255,255,255,0.56);
+      }
+      .activation-roadmap-title {
+        font-family: "Archivo", sans-serif;
+        font-size: clamp(1.8rem, 3.6vw, 2.7rem);
+        line-height: 1.15;
+        margin-top: 0.7rem;
+      }
+      .activation-roadmap-subtitle {
+        max-width: 42rem;
+        margin: 0.9rem auto 0;
+        font-family: "DM Sans", sans-serif;
+        color: rgba(255,255,255,0.72);
+        line-height: 1.6;
+        font-size: 0.95rem;
+      }
+      .activation-roadmap-grid {
+        display: grid;
+        grid-template-columns: repeat(3, minmax(0, 1fr));
+        gap: 1rem;
+      }
+      .activation-step-card {
+        border: 1px solid rgba(255,255,255,0.2);
+        border-radius: 16px;
+        background: linear-gradient(180deg, rgba(255,255,255,0.07), rgba(255,255,255,0.02));
+        padding: 1.2rem 1.15rem 1.25rem;
+        min-height: 100%;
+        display: flex;
+        flex-direction: column;
+      }
+      .activation-step-label {
+        font-family: "DM Sans", sans-serif;
+        font-size: 0.72rem;
+        letter-spacing: 0.11em;
+        text-transform: uppercase;
+        color: rgba(255,255,255,0.6);
+      }
+      .activation-step-title {
+        margin-top: 0.42rem;
+        font-family: "Archivo", sans-serif;
+        font-size: 1.32rem;
+        line-height: 1.22;
+      }
+      .activation-step-divider {
+        margin: 1rem 0 0.95rem;
+        border-top: 2px solid rgba(255,255,255,0.18);
+      }
+      .activation-step-text {
+        font-family: "DM Sans", sans-serif;
+        color: rgba(255,255,255,0.84);
+        line-height: 1.48;
+        font-size: 1rem;
+      }
+      .activation-step-cta {
+        margin-top: auto;
+        display: inline-flex;
+        align-items: center;
+        justify-content: center;
+        border: 1px solid rgba(255,255,255,0.45);
+        border-radius: 999px;
+        color: #fff;
+        text-decoration: none;
+        font-family: "Archivo", sans-serif;
+        font-size: 0.82rem;
+        letter-spacing: 0.06em;
+        text-transform: uppercase;
+        padding: 0.56rem 0.95rem;
+        margin-top: 1.15rem;
+        transition: all 0.2s ease;
+      }
+      .activation-step-cta:hover {
+        background: rgba(255,255,255,0.1);
+        border-color: rgba(255,255,255,0.72);
+      }
+      @media (max-width: 1024px) {
+        .activation-roadmap-grid {
+          grid-template-columns: 1fr;
+        }
+      }
     </style>
   </head>
 
@@ -455,6 +552,50 @@
           </a>
         </div>
         <div id="scroll-sentinel" class="h-6" aria-hidden="true"></div>
+      </section>
+
+      <section class="activation-roadmap">
+        <div class="activation-roadmap-inner">
+          <div class="activation-roadmap-head">
+            <div class="activation-roadmap-kicker">Participation Roadmap</div>
+            <h2 class="activation-roadmap-title">Activate Your Devcon Week</h2>
+            <p class="activation-roadmap-subtitle">
+              Come to Congress, get our week activation guide, and plug into the highest-signal events across the full Devcon week.
+            </p>
+          </div>
+
+          <div class="activation-roadmap-grid">
+            <article class="activation-step-card">
+              <div class="activation-step-label">Step 1</div>
+              <h3 class="activation-step-title">Join the Congress</h3>
+              <div class="activation-step-divider"></div>
+              <p class="activation-step-text">
+                Start with the main gathering in Mumbai and meet the core privacy builders, researchers, and partners in one place.
+              </p>
+              <a class="activation-step-cta" href="../index.html#tickets">Open Registration</a>
+            </article>
+
+            <article class="activation-step-card">
+              <div class="activation-step-label">Step 2</div>
+              <h3 class="activation-step-title">Get the Week Guide</h3>
+              <div class="activation-step-divider"></div>
+              <p class="activation-step-text">
+                We share a practical guide to activate all week: where to go, what to prioritize, and how to connect with the right circles.
+              </p>
+              <a class="activation-step-cta" href="https://t.me/+DMkrxGNeJzYyYzM0" target="_blank">Get Guide</a>
+            </article>
+
+            <article class="activation-step-card">
+              <div class="activation-step-label">Step 3</div>
+              <h3 class="activation-step-title">Maximize Impact</h3>
+              <div class="activation-step-divider"></div>
+              <p class="activation-step-text">
+                Follow the route from talks to side-events and working sessions, so your time translates into strong outcomes and long-term allies.
+              </p>
+              <a class="activation-step-cta" href="../index.html#program">See Program</a>
+            </article>
+          </div>
+        </div>
       </section>
 
       <!-- ======= CTA ======= -->

--- a/index.html
+++ b/index.html
@@ -2533,6 +2533,149 @@
         </div>
       </div>
 
+      <section id="week-roadmap" class="text-white px-4 my-24 md:my-32">
+        <style>
+          #week-roadmap .wr-shell {
+            max-width: 1240px;
+            margin: 0 auto;
+          }
+          #week-roadmap .wr-head {
+            text-align: center;
+            margin-bottom: 2rem;
+          }
+          #week-roadmap .wr-kicker {
+            display: inline-block;
+            font-family: "DM Sans", sans-serif;
+            font-size: 0.75rem;
+            letter-spacing: 0.13em;
+            text-transform: uppercase;
+            color: rgba(255,255,255,0.58);
+            border: 1px solid rgba(255,255,255,0.2);
+            border-radius: 999px;
+            padding: 0.34rem 0.92rem;
+          }
+          #week-roadmap .wr-title {
+            margin-top: 0.8rem;
+            font-family: "Archivo", sans-serif;
+            font-size: clamp(1.9rem, 3.8vw, 2.9rem);
+            line-height: 1.14;
+          }
+          #week-roadmap .wr-sub {
+            max-width: 46rem;
+            margin: 0.9rem auto 0;
+            font-family: "DM Sans", sans-serif;
+            color: rgba(255,255,255,0.74);
+            line-height: 1.55;
+            font-size: 0.95rem;
+          }
+          #week-roadmap .wr-grid {
+            display: grid;
+            grid-template-columns: repeat(3, minmax(0, 1fr));
+            gap: 1rem;
+          }
+          #week-roadmap .wr-card {
+            border: 1px solid rgba(255,255,255,0.2);
+            border-radius: 16px;
+            padding: 1.2rem 1.12rem 1.2rem;
+            background: linear-gradient(180deg, rgba(255,255,255,0.07), rgba(255,255,255,0.02));
+            min-height: 100%;
+            display: flex;
+            flex-direction: column;
+          }
+          #week-roadmap .wr-step {
+            font-family: "DM Sans", sans-serif;
+            font-size: 0.72rem;
+            letter-spacing: 0.1em;
+            text-transform: uppercase;
+            color: rgba(255,255,255,0.58);
+          }
+          #week-roadmap .wr-card-title {
+            margin-top: 0.45rem;
+            font-family: "Archivo", sans-serif;
+            font-size: 1.32rem;
+            line-height: 1.2;
+          }
+          #week-roadmap .wr-divider {
+            margin: 0.95rem 0 0.9rem;
+            border-top: 2px solid rgba(255,255,255,0.2);
+          }
+          #week-roadmap .wr-text {
+            font-family: "DM Sans", sans-serif;
+            color: rgba(255,255,255,0.86);
+            line-height: 1.5;
+            font-size: 1rem;
+          }
+          #week-roadmap .wr-cta {
+            margin-top: auto;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            border: 1px solid rgba(255,255,255,0.45);
+            border-radius: 999px;
+            text-decoration: none;
+            color: #fff;
+            font-family: "Archivo", sans-serif;
+            font-size: 0.82rem;
+            letter-spacing: 0.06em;
+            text-transform: uppercase;
+            padding: 0.55rem 0.96rem;
+            margin-top: 1.15rem;
+            transition: all 0.2s ease;
+          }
+          #week-roadmap .wr-cta:hover {
+            background: rgba(255,255,255,0.1);
+            border-color: rgba(255,255,255,0.72);
+          }
+          @media (max-width: 1024px) {
+            #week-roadmap .wr-grid {
+              grid-template-columns: 1fr;
+            }
+          }
+        </style>
+
+        <div class="wr-shell">
+          <div class="wr-head">
+            <div class="wr-kicker">Participation Roadmap</div>
+            <h2 class="wr-title">Activate Your Devcon Week</h2>
+            <p class="wr-sub">
+              Come to Congress, get our week activation guide, and turn every day of Devcon week into high-impact meetings, learnings, and collaborations.
+            </p>
+          </div>
+
+          <div class="wr-grid">
+            <article class="wr-card">
+              <div class="wr-step">Step 1</div>
+              <h3 class="wr-card-title">Come to Congress</h3>
+              <div class="wr-divider"></div>
+              <p class="wr-text">
+                Start from the core gathering and meet the strongest privacy builders, researchers, and partners in one place.
+              </p>
+              <a href="#tickets" class="wr-cta">Open Registration</a>
+            </article>
+
+            <article class="wr-card">
+              <div class="wr-step">Step 2</div>
+              <h3 class="wr-card-title">Get the Week Guide</h3>
+              <div class="wr-divider"></div>
+              <p class="wr-text">
+                We share a practical route for the full week: what to prioritize, where to go, and how to plug into the right communities fast.
+              </p>
+              <a href="https://t.me/+DMkrxGNeJzYyYzM0" target="_blank" class="wr-cta">Get Guide</a>
+            </article>
+
+            <article class="wr-card">
+              <div class="wr-step">Step 3</div>
+              <h3 class="wr-card-title">Maximize Your Impact</h3>
+              <div class="wr-divider"></div>
+              <p class="wr-text">
+                Follow the guide from talks to side-events and working sessions, so your Devcon week creates real outcomes and long-term allies.
+              </p>
+              <a href="#program" class="wr-cta">See Program</a>
+            </article>
+          </div>
+        </div>
+      </section>
+
       <!-- FAQ and Footer Wrapper -->
       <div class="faq-footer-wrapper" data-animate data-delay="100">
         <!-- FAQ Section -->


### PR DESCRIPTION
## Summary

This update adds a new **Participation Roadmap** section focused on helping people activate their full Devcon week.

## What was added

### 1) Community page (`community/index.html`)
- Added a new section below member cards:
  - **Participation Roadmap**
  - **Activate Your Devcon Week**
- Introduced 3-step flow:
  1. Join the Congress
  2. Get the Week Guide
  3. Maximize Impact
- Added matching CTAs:
  - Open Registration
  - Get Guide
  - See Program

### 2) Homepage (`index.html`)
- Added the same **Participation Roadmap / Activate Your Devcon Week** block
- Positioned it right before **Frequently Asked Questions**

## Additional polish
- Kept section responsive and aligned with the site’s visual language.
- Preserved desktop behavior while improving mobile readability in the community page.