### PR TITLE
Add Projects directory page

### DIFF
--- a/index.html
+++ b/index.html
@@ -70,6 +70,9 @@
                 <a class="nav-link-minimal" href="./community/">Community</a>
               </div>
               <div class="m-1">
+                <a class="nav-link-minimal" href="./projects/">Projects</a>
+              </div>
+              <div class="m-1">
                 <a class="nav-link-minimal" href="#partners"> Partners</a>
               </div>
               <div class="m-1">
@@ -121,6 +124,9 @@
               </div>
               <div class="mobile-nav-item">
                 <a class="nav-link-minimal" href="./community/">Community</a>
+              </div>
+              <div class="mobile-nav-item">
+                <a class="nav-link-minimal" href="./projects/">Projects</a>
               </div>
               <div class="mobile-nav-item">
                 <a class="nav-link-minimal" href="#partners">Partners</a>

--- a/projects/index.html
+++ b/projects/index.html
@@ -1,0 +1,994 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta http-equiv="content-type" content="text/html; charset=UTF-8" />
+    <meta name="viewport" content="width=device-width" />
+    <meta name="theme-color" content="#000000" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=DM+Sans:wght@300;400;600&family=Archivo:wght@600&display=swap" rel="stylesheet" />
+    <link rel="stylesheet" href="https://use.typekit.net/xdd8rzp.css" />
+    <link href="../community/styles/output.css" rel="stylesheet" />
+    <link href="../community/styles/w3pevent.css" rel="stylesheet" />
+    <title>W3Privacy Projects</title>
+    <meta name="description" content="Explore the projects and organizations building the privacy stack — grouped by team, filterable by technology." />
+    <style>
+      /* Re-declare local fonts since w3pevent.css uses absolute /fonts/ paths */
+      @font-face {
+        font-family: "Major Mono Display";
+        font-style: normal;
+        font-weight: 400;
+        src: url('../fonts/major-mono-display-v13-latin-regular.woff2') format('woff2'),
+             url('../fonts/major-mono-display-v13-latin-regular.woff') format('woff'),
+             url('../fonts/major-mono-display-v13-latin-regular.ttf') format('truetype');
+      }
+      @font-face {
+        font-family: "Archivo";
+        font-style: normal;
+        font-weight: 400;
+        src: url('../fonts/Archivo.ttf') format('truetype');
+      }
+      @font-face {
+        font-family: "KyivTypeSerif";
+        font-style: normal;
+        font-weight: 900;
+        src: url('../fonts/KyivTypeSerif-Heavy2.ttf') format('truetype');
+      }
+      @font-face {
+        font-family: "aileron";
+        font-style: normal;
+        font-weight: 600;
+        src: url('../fonts/aileron/aileron.semibold.otf') format('opentype');
+      }
+
+      /* Direction badge base */
+      .direction-badge {
+        display: inline-block;
+        padding: 0.2rem 0.65rem;
+        border-radius: 20px;
+        font-size: 0.66rem;
+        font-family: "DM Sans", sans-serif;
+        font-weight: 400;
+        color: rgba(255, 255, 255, 0.85);
+        letter-spacing: 0.02em;
+        border: 1px solid rgba(255, 255, 255, 0.18);
+        background: rgba(255, 255, 255, 0.05);
+        white-space: nowrap;
+      }
+      .dir-crypto      { background: #1a1a3a; }
+      .dir-identity    { background: #1a0a2d; }
+      .dir-wallets     { background: #2a1a0a; }
+      .dir-messaging   { background: #1a2d2d; }
+      .dir-network     { background: #0a1a2a; }
+      .dir-storage     { background: #0a2a1a; }
+      .dir-protocol    { background: #1b2354; }
+      .dir-governance  { background: #2d2d1a; }
+      .dir-legal       { background: #2d1a1a; }
+      .dir-security    { background: #2d1a2d; }
+      .dir-browser     { background: #1a2d1a; }
+      .dir-rights      { background: #2a0a1a; }
+
+      .project-item:hover .direction-badge {
+        filter: brightness(1.6);
+        border-color: rgba(0, 0, 0, 0.15);
+      }
+
+      /* Hero section */
+      .community-hero {
+        padding-top: 7rem;
+        padding-bottom: 3.5rem;
+        text-align: center;
+        padding-left: 1.5rem;
+        padding-right: 1.5rem;
+      }
+      .community-hero h1 {
+        font-family: "aileron", sans-serif;
+        font-weight: 600;
+        font-size: clamp(2rem, 5vw, 3.5rem);
+        color: #ffffff;
+        letter-spacing: 0.02em;
+        margin-top: 1rem;
+        line-height: 1.15;
+      }
+      .community-hero p {
+        font-family: "DM Sans", sans-serif;
+        font-weight: 300;
+        font-size: 1.05rem;
+        color: rgba(255, 255, 255, 0.72);
+        max-width: 40rem;
+        margin: 1.1rem auto 0;
+        line-height: 1.65;
+      }
+
+      #filter-bar {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.5rem;
+        margin-bottom: 0.75rem;
+        width: 100%;
+        box-sizing: border-box;
+      }
+      .filter-controls {
+        margin-bottom: 2rem;
+      }
+      #filter-toggle {
+        display: none;
+        border: 1px solid rgba(255, 255, 255, 0.22);
+        background: transparent;
+        color: rgba(255, 255, 255, 0.72);
+        border-radius: 9999px;
+        padding: 0.32rem 0.85rem;
+        font-size: 0.75rem;
+        font-family: "DM Sans", sans-serif;
+        cursor: pointer;
+      }
+      #filter-toggle:hover {
+        border-color: rgba(255,255,255,0.55);
+        color: #fff;
+      }
+      .filter-pill {
+        padding: 0.35rem 1rem;
+        border-radius: 9999px;
+        font-size: 0.78rem;
+        font-family: "DM Sans", sans-serif;
+        font-weight: 400;
+        border: 1px solid rgba(255, 255, 255, 0.22);
+        background: transparent;
+        color: rgba(255, 255, 255, 0.65);
+        cursor: pointer;
+        transition: all 0.18s ease;
+        flex-shrink: 0;
+      }
+      .filter-pill:hover { border-color: rgba(255,255,255,0.55); color: #fff; }
+      .filter-pill.active { background: #fff; color: #000; border-color: #fff; font-weight: 600; }
+
+      @media (max-width: 768px) {
+        #filter-toggle {
+          display: inline-flex;
+          align-items: center;
+          justify-content: center;
+        }
+        #filter-bar .mobile-hidden-filter {
+          display: none !important;
+        }
+      }
+
+      .section-label {
+        font-family: "DM Sans", sans-serif;
+        font-weight: 400;
+        font-size: 0.78rem;
+        letter-spacing: 0.12em;
+        text-transform: uppercase;
+        color: rgba(255, 255, 255, 0.5);
+        margin-bottom: 1.5rem;
+        padding-bottom: 0.75rem;
+        border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+      }
+
+      /* ======= PROJECT CARD ======= */
+      /* Plain grid, not masonry: every card is built from fixed-height
+         sub-sections (1-line title, capped badges, 2-line desc, a 3-slot
+         member row) so all cards in the grid come out the same height
+         without needing to force/clip anything. */
+      .project-grid {
+        display: grid;
+        grid-template-columns: 1fr;
+        gap: 1.25rem;
+      }
+      @media (min-width: 640px) {
+        .project-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+      }
+      @media (min-width: 1024px) {
+        .project-grid { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+      }
+      @media (min-width: 1600px) {
+        .project-grid { grid-template-columns: repeat(4, minmax(0, 1fr)); }
+      }
+
+      .project-item {
+        border: 1px solid rgba(255, 255, 255, 0.18);
+        border-radius: 18px;
+        padding: 1.35rem;
+        display: flex;
+        flex-direction: column;
+        min-width: 0;
+        background: linear-gradient(180deg, rgba(255,255,255,0.035), rgba(255,255,255,0.005));
+        transition: border-color 0.2s ease, background 0.2s ease;
+      }
+      .project-item:hover {
+        border-color: rgba(255, 255, 255, 0.45);
+        background: linear-gradient(180deg, rgba(255,255,255,0.07), rgba(255,255,255,0.01));
+      }
+
+      .project-head {
+        display: flex;
+        align-items: center;
+        gap: 0.75rem;
+        margin-bottom: 0.85rem;
+        height: 40px;
+      }
+      .project-icon {
+        width: 40px;
+        height: 40px;
+        border-radius: 10px;
+        object-fit: contain;
+        background: rgba(255, 255, 255, 0.08);
+        border: 1px solid rgba(255, 255, 255, 0.14);
+        padding: 6px;
+        flex-shrink: 0;
+      }
+      .project-icon-fallback {
+        width: 40px;
+        height: 40px;
+        border-radius: 10px;
+        background: rgba(255, 255, 255, 0.08);
+        border: 1px solid rgba(255, 255, 255, 0.14);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-family: "Archivo", sans-serif;
+        font-size: 0.95rem;
+        color: rgba(255,255,255,0.75);
+        flex-shrink: 0;
+      }
+      .project-name {
+        font-family: "Archivo", sans-serif;
+        font-size: 1.15rem;
+        line-height: 1.3;
+        color: #fff;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        min-width: 0;
+      }
+
+      .direction-row {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 0.35rem;
+        margin-bottom: 0.9rem;
+        height: 24px;
+        min-width: 0;
+        overflow: hidden;
+      }
+      .direction-badge-more {
+        color: rgba(255, 255, 255, 0.55);
+        border-style: dashed;
+        background: transparent !important;
+      }
+
+      .project-desc {
+        font-family: "DM Sans", sans-serif;
+        font-style: italic;
+        font-weight: 300;
+        font-size: 0.9rem;
+        line-height: 1.5;
+        color: rgba(255, 255, 255, 0.75);
+        display: -webkit-box;
+        -webkit-box-orient: vertical;
+        -webkit-line-clamp: 2;
+        overflow: hidden;
+        min-width: 0;
+        height: 2.7rem;
+        margin-bottom: 0.5rem;
+      }
+
+      .read-more-link {
+        display: inline-block;
+        font-family: "DM Sans", sans-serif;
+        font-size: 0.82rem;
+        font-weight: 400;
+        color: rgba(255, 255, 255, 0.9);
+        text-decoration: underline;
+        text-underline-offset: 2px;
+        cursor: pointer;
+        background: none;
+        border: none;
+        padding: 0;
+        margin-bottom: 0.9rem;
+      }
+      .read-more-link:hover { color: #fff; }
+
+      .project-divider {
+        border-top: 1px solid rgba(255, 255, 255, 0.12);
+        margin-bottom: 1rem;
+        margin-top: auto;
+        padding-top: 1rem;
+      }
+
+      .member-row {
+        display: grid;
+        grid-template-columns: repeat(3, 1fr);
+        gap: 0.6rem;
+        min-width: 0;
+      }
+      .member-row.modal-member-row {
+        grid-template-columns: repeat(auto-fill, minmax(84px, 1fr));
+      }
+      @media (max-width: 639px) {
+        /* Single-column card layout below this width: no sibling card
+           shares a row, so it's safe to trade the fixed 3-up grid for
+           fewer, bigger, more legible tiles. */
+        .member-row:not(.modal-member-row) {
+          grid-template-columns: repeat(2, 1fr);
+        }
+      }
+      .member-chip {
+        display: block;
+        border: 1px solid rgba(255, 255, 255, 0.14);
+        border-radius: 10px;
+        background: rgba(255, 255, 255, 0.03);
+        overflow: hidden;
+        min-width: 0;
+        text-decoration: none;
+        transition: border-color 0.18s ease, background 0.18s ease;
+      }
+      .member-chip:hover {
+        border-color: rgba(255, 255, 255, 0.4);
+        background: rgba(255, 255, 255, 0.06);
+      }
+      .member-chip img {
+        display: block;
+        width: 100%;
+        min-width: 0;
+        max-width: 100%;
+        aspect-ratio: 1 / 1;
+        object-fit: cover;
+        border-bottom: 1px solid rgba(255, 255, 255, 0.12);
+      }
+      .member-chip-name {
+        font-family: "DM Sans", sans-serif;
+        font-weight: 600;
+        font-size: 0.68rem;
+        color: #fff;
+        margin-top: 0.4rem;
+        padding: 0 0.4rem;
+        line-height: 1.25;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+      .member-chip-role {
+        font-family: "DM Sans", sans-serif;
+        font-weight: 300;
+        font-size: 0.62rem;
+        color: rgba(255, 255, 255, 0.6);
+        line-height: 1.3;
+        margin-top: 0.15rem;
+        padding: 0 0.4rem 0.5rem;
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
+      .member-more-tile {
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        border: 1px dashed rgba(255, 255, 255, 0.25);
+        border-radius: 10px;
+        font-family: "DM Sans", sans-serif;
+        font-weight: 600;
+        font-size: 0.78rem;
+        color: rgba(255, 255, 255, 0.6);
+        background: rgba(255, 255, 255, 0.02);
+      }
+
+      /* ======= MODAL ======= */
+      .project-modal-backdrop {
+        position: fixed;
+        inset: 0;
+        background: rgba(0, 0, 0, 0.75);
+        backdrop-filter: blur(4px);
+        display: none;
+        align-items: center;
+        justify-content: center;
+        z-index: 100;
+        padding: 1.5rem;
+      }
+      .project-modal-backdrop.open {
+        display: flex;
+      }
+      .project-modal {
+        background: #0a0a0a;
+        border: 1px solid rgba(255, 255, 255, 0.2);
+        border-radius: 18px;
+        max-width: 34rem;
+        width: 100%;
+        max-height: 85vh;
+        overflow-y: auto;
+        padding: 2rem;
+        position: relative;
+      }
+      @media (max-width: 480px) {
+        .project-modal-backdrop { padding: 0.75rem; }
+        .project-modal { padding: 1.25rem; }
+        .project-modal-close { top: 0.75rem; right: 0.75rem; }
+      }
+      .project-modal-close {
+        position: absolute;
+        top: 1rem;
+        right: 1rem;
+        width: 32px;
+        height: 32px;
+        border-radius: 50%;
+        border: 1px solid rgba(255, 255, 255, 0.25);
+        background: transparent;
+        color: rgba(255, 255, 255, 0.7);
+        cursor: pointer;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 1.1rem;
+        line-height: 1;
+      }
+      .project-modal-close:hover {
+        color: #fff;
+        border-color: rgba(255, 255, 255, 0.6);
+      }
+      .project-modal-head {
+        display: flex;
+        align-items: center;
+        gap: 0.9rem;
+        margin-bottom: 1rem;
+        padding-right: 2rem;
+      }
+      .project-modal-head img.project-icon,
+      .project-modal-head .project-icon-fallback {
+        width: 48px;
+        height: 48px;
+      }
+      .project-modal-title {
+        font-family: "Archivo", sans-serif;
+        font-size: 1.4rem;
+        color: #fff;
+      }
+      .project-modal-desc {
+        font-family: "DM Sans", sans-serif;
+        font-weight: 300;
+        font-size: 0.95rem;
+        line-height: 1.7;
+        color: rgba(255, 255, 255, 0.85);
+        margin-bottom: 1.25rem;
+      }
+      .project-modal-link {
+        display: inline-flex;
+        align-items: center;
+        gap: 0.4rem;
+        font-family: "DM Sans", sans-serif;
+        font-size: 0.85rem;
+        color: rgba(255, 255, 255, 0.9);
+        text-decoration: none;
+        border: 1px solid rgba(255, 255, 255, 0.3);
+        border-radius: 999px;
+        padding: 0.45rem 1rem;
+        transition: all 0.18s ease;
+      }
+      .project-modal-link:hover {
+        border-color: #fff;
+        background: rgba(255, 255, 255, 0.08);
+      }
+      .modal-direction-row {
+        height: auto;
+        overflow: visible;
+      }
+      .project-modal-team-label {
+        font-family: "DM Sans", sans-serif;
+        font-weight: 400;
+        font-size: 0.7rem;
+        letter-spacing: 0.1em;
+        text-transform: uppercase;
+        color: rgba(255, 255, 255, 0.5);
+        margin: 1.5rem 0 0.75rem;
+      }
+
+      .empty-state {
+        font-family: "DM Sans", sans-serif;
+        color: rgba(255, 255, 255, 0.5);
+        font-size: 0.9rem;
+        padding: 2rem 0;
+        break-inside: avoid;
+        text-align: center;
+      }
+    </style>
+  </head>
+
+  <body class="bg-black text-white" style="overflow-x:hidden;">
+    <div class="relative w-full min-h-screen text-white">
+
+      <!-- ======= NAVBAR ======= -->
+      <div id="header" class="fixed w-full h-18 z-40 top-0">
+        <input type="checkbox" id="mobile-menu-toggle" class="mobile-menu-checkbox hidden" />
+        <div class="navbar-minimal px-10 py-4 pt-2">
+          <!-- Desktop Navigation -->
+          <div class="desktop-nav flex justify-between items-center my-1">
+            <div class="flex items-center">
+              <a href="https://web3privacy.info/" target="_blank">
+                <img src="../img/logo5.svg" alt="Web3Privacy Now" class="w-52" />
+              </a>
+            </div>
+            <div class="flex items-center gap-8 text-base">
+              <div class="m-1">
+                <a class="nav-link-minimal" href="../index.html#intro">Home</a>
+              </div>
+              <div class="m-1">
+                <a class="nav-link-minimal" href="../index.html#speakers">Speakers</a>
+              </div>
+              <div class="m-1">
+                <a class="nav-link-minimal" href="../index.html#program">Program</a>
+              </div>
+              <div class="m-1">
+                <a class="nav-link-minimal" href="../community/index.html">Community</a>
+              </div>
+              <div class="m-1">
+                <a class="nav-link-minimal active" href="index.html">Projects</a>
+              </div>
+              <div class="m-1">
+                <a class="nav-link-minimal" href="../index.html#partners">Partners</a>
+              </div>
+              <div class="m-1">
+                <a class="nav-link-minimal" href="https://tally.so/r/3lLqKo" target="_blank">Volunteer with Us</a>
+              </div>
+            </div>
+          </div>
+          <!-- Mobile Navigation -->
+          <div class="mobile-nav flex justify-between items-center">
+            <div class="mobile-logo">
+              <a href="https://web3privacy.info/" target="_blank">
+                <img src="../img/logo5.svg" alt="Web3Privacy Now" class="w-40" />
+              </a>
+            </div>
+            <div class="mobile-nav-controls">
+              <label for="mobile-menu-toggle" class="hamburger-icon" data-hidden="false">
+                <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M3 12H21" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
+                  <path d="M3 6H21" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
+                  <path d="M3 18H21" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
+                </svg>
+              </label>
+              <label for="mobile-menu-toggle" class="close-icon" data-hidden="true">
+                <svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+                  <path d="M18 6L6 18" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
+                  <path d="M6 6L18 18" stroke="currentColor" stroke-width="2" stroke-linecap="round" />
+                </svg>
+              </label>
+            </div>
+          </div>
+          <!-- Mobile Menu Panel -->
+          <div class="mobile-menu-panel" data-hidden="true">
+            <div class="mobile-menu-items">
+              <div class="mobile-nav-item">
+                <a class="nav-link-minimal" href="../index.html#intro">Home</a>
+              </div>
+              <div class="mobile-nav-item">
+                <a class="nav-link-minimal" href="../index.html#speakers">Speakers</a>
+              </div>
+              <div class="mobile-nav-item">
+                <a class="nav-link-minimal" href="../index.html#program">Program</a>
+              </div>
+              <div class="mobile-nav-item">
+                <a class="nav-link-minimal" href="../community/index.html">Community</a>
+              </div>
+              <div class="mobile-nav-item">
+                <a class="nav-link-minimal active" href="index.html">Projects</a>
+              </div>
+              <div class="mobile-nav-item">
+                <a class="nav-link-minimal" href="../index.html#partners">Partners</a>
+              </div>
+              <div class="mobile-nav-item">
+                <a class="nav-link-minimal" href="https://tally.so/r/3lLqKo" target="_blank">Volunteer with Us</a>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+      <!-- ======= END NAVBAR ======= -->
+
+      <!-- ======= HERO ======= -->
+      <section class="community-hero">
+        <h1>Projects Directory</h1>
+        <p>
+          The organizations building the privacy stack — grouped by team, not by name tag.
+          Filter by technology to see the breadth of what's being built, and who's building it.
+        </p>
+      </section>
+
+      <!-- ======= PROJECTS GRID ======= -->
+      <section class="px-6 md:px-16 lg:px-24 pb-16">
+        <div class="section-label">Projects &mdash; <span id="projects-count">0 projects</span></div>
+        <div id="filter-bar"></div>
+        <div class="filter-controls">
+          <button id="filter-toggle" type="button" aria-expanded="false">Show all filters</button>
+        </div>
+
+        <div id="project-grid" class="project-grid"></div>
+      </section>
+
+      <!-- ======= FOOTER ======= -->
+      <footer class="mobile-footer">
+        <div class="footer-top-section">
+          <h3 class="footer-main-title">Web3Privacy Now</h3>
+          <p class="footer-description">Grassroots collective empowering privacy &amp; freedom in the future web.</p>
+        </div>
+        <div class="footer-bottom-section">
+          <div class="footer-column">
+            <h4 class="footer-column-title">Collective</h4>
+            <ul class="footer-links-list">
+              <li><a href="../index.html#intro" class="footer-link">Home</a></li>
+              <li><a href="../index.html#program" class="footer-link">Program</a></li>
+              <li><a href="../community/index.html" class="footer-link">Community</a></li>
+              <li><a href="index.html" class="footer-link">Projects</a></li>
+            </ul>
+          </div>
+          <div class="footer-column">
+            <h4 class="footer-column-title">Contact</h4>
+            <ul class="footer-links-list">
+              <li><a href="https://t.me/+DMkrxGNeJzYyYzM0" class="footer-link" target="_blank">Telegram</a></li>
+              <li><a href="https://twitter.com/web3privacy" class="footer-link" target="_blank">Twitter</a></li>
+              <li><a href="https://www.youtube.com/@Web3PrivacyNow" class="footer-link" target="_blank">Youtube</a></li>
+            </ul>
+          </div>
+        </div>
+      </footer>
+
+    </div>
+
+    <!-- ======= READ MORE MODAL ======= -->
+    <div id="project-modal-backdrop" class="project-modal-backdrop">
+      <div class="project-modal" role="dialog" aria-modal="true" aria-labelledby="project-modal-title">
+        <button type="button" class="project-modal-close" id="project-modal-close" aria-label="Close">&times;</button>
+        <div class="project-modal-head">
+          <div id="project-modal-icon-wrap"></div>
+          <div id="project-modal-title" class="project-modal-title"></div>
+        </div>
+        <div id="project-modal-directions" class="direction-row modal-direction-row"></div>
+        <p id="project-modal-desc" class="project-modal-desc modal-project-desc"></p>
+        <a id="project-modal-link" class="project-modal-link" href="#" target="_blank" rel="noopener noreferrer">
+          Visit website
+          <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M7 17L17 7M17 7H7M17 7V17"/></svg>
+        </a>
+        <div class="project-modal-team-label">Team</div>
+        <div id="project-modal-members" class="member-row modal-member-row"></div>
+      </div>
+    </div>
+
+    <script>
+      (function () {
+        var projects = [];
+        var filteredProjects = [];
+        var activeFilters = new Set();
+        var isFilterExpanded = false;
+        var MOBILE_FILTER_LIMIT = 5;
+
+        var filterBar = document.getElementById('filter-bar');
+        var filterToggle = document.getElementById('filter-toggle');
+        var projectGrid = document.getElementById('project-grid');
+        var projectsCount = document.getElementById('projects-count');
+
+        var modalBackdrop = document.getElementById('project-modal-backdrop');
+        var modalClose = document.getElementById('project-modal-close');
+        var modalIconWrap = document.getElementById('project-modal-icon-wrap');
+        var modalTitle = document.getElementById('project-modal-title');
+        var modalDirections = document.getElementById('project-modal-directions');
+        var modalDesc = document.getElementById('project-modal-desc');
+        var modalLink = document.getElementById('project-modal-link');
+        var modalMembers = document.getElementById('project-modal-members');
+
+        var directionClassMap = {
+          'Cryptography & ZK': 'dir-crypto',
+          'Identity & Credentials': 'dir-identity',
+          'Wallets & Payments': 'dir-wallets',
+          'Messaging & Social': 'dir-messaging',
+          'Networking & Mixnets': 'dir-network',
+          'Storage & Infra': 'dir-storage',
+          'Protocol & Research': 'dir-protocol',
+          'Governance & Public Goods': 'dir-governance',
+          'Legal & Policy': 'dir-legal',
+          'Security & Auditing': 'dir-security',
+          'Browsers & Apps': 'dir-browser',
+          'Digital Rights & Advocacy': 'dir-rights'
+        };
+
+        function escapeHtml(value) {
+          return String(value || '')
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;')
+            .replace(/'/g, '&#39;');
+        }
+
+        function initials(name) {
+          var parts = String(name || '').trim().split(/\s+/).filter(Boolean);
+          if (!parts.length) return '?';
+          if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+          return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+        }
+
+        function iconHtml(project, size) {
+          var sizeStyle = 'width:' + size + 'px;height:' + size + 'px;';
+          var fallback = '<div class="project-icon-fallback" style="' + sizeStyle + '">' + escapeHtml(initials(project.name)) + '</div>';
+          if (!project.icon) return fallback;
+          return '<span class="project-icon-slot" style="display:inline-flex;' + sizeStyle + '">' +
+            '<img src="' + escapeHtml(project.icon) + '" alt="" class="project-icon" style="' + sizeStyle + '" loading="lazy" ' +
+            'onerror="this.style.display=&#39;none&#39;;this.nextElementSibling.style.display=&#39;flex&#39;;" />' +
+            '<div class="project-icon-fallback" style="' + sizeStyle + 'display:none;">' + escapeHtml(initials(project.name)) + '</div>' +
+            '</span>';
+        }
+
+        var CARD_MEMBER_LIMIT = 3;
+
+        function cardDirectionLimit() {
+          // Two long badges ("Governance & Public Goods" etc.) don't fit
+          // on the fixed single-line badge row once the card narrows to a
+          // 1- or 2-up layout — cap to 1 there so the row never silently
+          // clips a badge that doesn't wrap into view.
+          return window.matchMedia('(max-width: 1023px)').matches ? 1 : 2;
+        }
+
+        function directionBadgesHtml(directions, limit) {
+          var shown = limit ? directions.slice(0, limit) : directions;
+          var hidden = limit ? directions.length - shown.length : 0;
+          var html = shown.map(function (direction) {
+            var cls = directionClassMap[direction] || 'dir-rights';
+            return '<span class="direction-badge ' + cls + '">' + escapeHtml(direction) + '</span>';
+          }).join('');
+          if (hidden > 0) {
+            html += '<span class="direction-badge direction-badge-more">+' + hidden + '</span>';
+          }
+          return html;
+        }
+
+        function memberChipHtml(member) {
+          var caption = member.role || '';
+          var href = member.xUrl ? ' href="' + escapeHtml(member.xUrl) + '" target="_blank" rel="noopener noreferrer"' : '';
+          var tag = member.xUrl ? 'a' : 'div';
+          return '<' + tag + ' class="member-chip"' + href + '>' +
+            '<img src="' + escapeHtml(member.photo) + '" alt="' + escapeHtml(member.name) + '" loading="lazy" />' +
+            '<div class="member-chip-name" style="' + (caption ? '' : 'padding-bottom:0.5rem;') + '">' + escapeHtml(member.name) + '</div>' +
+            (caption ? '<div class="member-chip-role">' + escapeHtml(caption) + '</div>' : '') +
+            '</' + tag + '>';
+        }
+
+        function memberRowHtml(members, limit) {
+          // Reserve one tile for the "+N" indicator so the total tile count
+          // never exceeds `limit` (keeps the row to a single grid row).
+          var needsMore = limit && members.length > limit;
+          var shownCount = needsMore ? limit - 1 : (limit || members.length);
+          var shown = members.slice(0, shownCount);
+          var hidden = members.length - shown.length;
+          var html = shown.map(memberChipHtml).join('');
+          if (hidden > 0) {
+            html += '<div class="member-more-tile">+' + hidden + '</div>';
+          }
+          return html;
+        }
+
+        function createProjectCard(project) {
+          var card = document.createElement('div');
+          card.className = 'project-item';
+          card.dataset.directions = project.direction.join('|');
+          card.dataset.slug = project.slug;
+
+          card.innerHTML =
+            '<div class="project-head">' +
+              iconHtml(project, 40) +
+              '<div class="project-name">' + escapeHtml(project.name) + '</div>' +
+            '</div>' +
+            '<div class="direction-row">' + directionBadgesHtml(project.direction, cardDirectionLimit()) + '</div>' +
+            '<p class="project-desc">' + escapeHtml(project.description) + '</p>' +
+            '<button type="button" class="read-more-link" data-slug="' + escapeHtml(project.slug) + '">Read more.</button>' +
+            '<div class="project-divider"></div>' +
+            '<div class="member-row">' + memberRowHtml(project.members, CARD_MEMBER_LIMIT) + '</div>';
+
+          return card;
+        }
+
+        function renderProjects() {
+          projectGrid.innerHTML = '';
+          projectsCount.textContent = filteredProjects.length + ' projects';
+
+          if (!filteredProjects.length) {
+            var empty = document.createElement('div');
+            empty.className = 'empty-state';
+            empty.textContent = 'No projects match this filter yet.';
+            projectGrid.appendChild(empty);
+            return;
+          }
+
+          filteredProjects.forEach(function (project) {
+            projectGrid.appendChild(createProjectCard(project));
+          });
+        }
+
+        function applyFilters() {
+          if (activeFilters.size === 0) {
+            filteredProjects = projects.slice();
+          } else {
+            filteredProjects = projects.filter(function (project) {
+              return project.direction.some(function (direction) { return activeFilters.has(direction); });
+            });
+          }
+          renderProjects();
+        }
+
+        function buildFilterBar() {
+          var directions = Array.from(new Set(
+            projects.reduce(function (acc, project) { return acc.concat(project.direction); }, [])
+          ));
+          directions.sort(function (a, b) { return a.localeCompare(b); });
+
+          filterBar.innerHTML = '';
+
+          var allButton = document.createElement('button');
+          allButton.className = 'filter-pill active';
+          allButton.type = 'button';
+          allButton.dataset.direction = 'All';
+          allButton.textContent = 'All';
+          filterBar.appendChild(allButton);
+
+          directions.forEach(function (direction) {
+            var button = document.createElement('button');
+            button.className = 'filter-pill';
+            button.type = 'button';
+            button.dataset.direction = direction;
+            button.textContent = direction;
+            filterBar.appendChild(button);
+          });
+
+          updateMobileFilterVisibility();
+        }
+
+        function updateMobileFilterVisibility() {
+          if (!filterToggle) return;
+          var pills = Array.from(filterBar.querySelectorAll('.filter-pill'));
+          var isMobile = window.matchMedia('(max-width: 768px)').matches;
+
+          pills.forEach(function (pill) {
+            pill.classList.remove('mobile-hidden-filter');
+          });
+
+          if (!isMobile) {
+            filterToggle.style.display = 'none';
+            return;
+          }
+
+          if (pills.length <= MOBILE_FILTER_LIMIT + 1) {
+            filterToggle.style.display = 'none';
+            return;
+          }
+
+          filterToggle.style.display = 'inline-flex';
+          if (!isFilterExpanded) {
+            for (var i = MOBILE_FILTER_LIMIT + 1; i < pills.length; i++) {
+              if (!pills[i].classList.contains('active')) {
+                pills[i].classList.add('mobile-hidden-filter');
+              }
+            }
+            filterToggle.textContent = 'Show all filters';
+            filterToggle.setAttribute('aria-expanded', 'false');
+          } else {
+            filterToggle.textContent = 'Show fewer';
+            filterToggle.setAttribute('aria-expanded', 'true');
+          }
+        }
+
+        function setupFilterToggle() {
+          if (!filterToggle) return;
+          filterToggle.addEventListener('click', function () {
+            isFilterExpanded = !isFilterExpanded;
+            updateMobileFilterVisibility();
+          });
+
+          var lastDirectionLimit = cardDirectionLimit();
+          window.addEventListener('resize', function () {
+            updateMobileFilterVisibility();
+            // Re-render if crossing the breakpoint where the badge cap
+            // changes (e.g. rotating a tablet), not on every resize tick.
+            var limit = cardDirectionLimit();
+            if (limit !== lastDirectionLimit) {
+              lastDirectionLimit = limit;
+              renderProjects();
+            }
+          });
+        }
+
+        function setupFilterEvents() {
+          filterBar.addEventListener('click', function (event) {
+            var pill = event.target.closest('.filter-pill');
+            if (!pill) return;
+
+            var direction = pill.dataset.direction;
+            if (direction === 'All') {
+              activeFilters.clear();
+              filterBar.querySelectorAll('.filter-pill').forEach(function (node) {
+                node.classList.remove('active');
+              });
+              pill.classList.add('active');
+            } else {
+              var allPill = filterBar.querySelector('.filter-pill[data-direction="All"]');
+              if (allPill) allPill.classList.remove('active');
+
+              if (activeFilters.has(direction)) {
+                activeFilters.delete(direction);
+                pill.classList.remove('active');
+                if (activeFilters.size === 0 && allPill) {
+                  allPill.classList.add('active');
+                }
+              } else {
+                activeFilters.add(direction);
+                pill.classList.add('active');
+              }
+            }
+
+            applyFilters();
+            updateMobileFilterVisibility();
+          });
+        }
+
+        function openModal(project) {
+          modalIconWrap.innerHTML = iconHtml(project, 48);
+          modalTitle.textContent = project.name;
+          modalDirections.innerHTML = directionBadgesHtml(project.direction);
+          modalDesc.textContent = project.descriptionFull || project.description;
+          modalMembers.innerHTML = memberRowHtml(project.members);
+          if (project.orgUrl) {
+            modalLink.href = project.orgUrl;
+            modalLink.style.display = 'inline-flex';
+          } else {
+            modalLink.style.display = 'none';
+          }
+          modalBackdrop.classList.add('open');
+          document.body.style.overflow = 'hidden';
+        }
+
+        function closeModal() {
+          modalBackdrop.classList.remove('open');
+          document.body.style.overflow = '';
+        }
+
+        function setupModalEvents() {
+          projectGrid.addEventListener('click', function (event) {
+            var trigger = event.target.closest('.read-more-link');
+            if (!trigger) return;
+            var slug = trigger.dataset.slug;
+            var project = projects.find(function (p) { return p.slug === slug; });
+            if (project) openModal(project);
+          });
+
+          modalClose.addEventListener('click', closeModal);
+          modalBackdrop.addEventListener('click', function (event) {
+            if (event.target === modalBackdrop) closeModal();
+          });
+          document.addEventListener('keydown', function (event) {
+            if (event.key === 'Escape' && modalBackdrop.classList.contains('open')) closeModal();
+          });
+        }
+
+        function renderErrorState() {
+          projectsCount.textContent = '0 projects';
+          var note = document.createElement('div');
+          note.className = 'empty-state';
+          note.textContent = 'Could not load projects data.';
+          projectGrid.appendChild(note);
+        }
+
+        fetch('./projects.json', { cache: 'no-store' })
+          .then(function (response) {
+            if (!response.ok) throw new Error('Failed to load projects JSON');
+            return response.json();
+          })
+          .then(function (data) {
+            projects = Array.isArray(data) ? data : [];
+            buildFilterBar();
+            setupFilterToggle();
+            setupFilterEvents();
+            setupModalEvents();
+            applyFilters();
+          })
+          .catch(function () {
+            renderErrorState();
+          });
+      })();
+    </script>
+  </body>
+</html>

--- a/projects/projects.json
+++ b/projects/projects.json
@@ -1,0 +1,1741 @@
+[
+  {
+    "slug": "ethereum-foundation",
+    "name": "Ethereum Foundation",
+    "orgUrl": "https://ethereum.org/foundation/",
+    "icon": "https://www.google.com/s2/favicons?sz=128&domain=ethereum.org",
+    "curated": true,
+    "description": "Nonprofit stewarding Ethereum protocol research, scalability, and cryptography.",
+    "direction": [
+      "Protocol & Research",
+      "Governance & Public Goods"
+    ],
+    "members": [
+      {
+        "name": "JUSTIN DRAKE",
+        "photo": "../img/justindrake.jpg",
+        "xUrl": "https://x.com/drakefjustin",
+        "role": "Research",
+        "tagline": "Key protocol researcher"
+      },
+      {
+        "name": "VITALIK BUTERIN",
+        "photo": "../img/vitalik-buterin.webp",
+        "xUrl": "https://x.com/vitalikbuterin",
+        "role": "Founder",
+        "tagline": "Helping protocols & institutions adopt ZK-tech"
+      },
+      {
+        "name": "NICO CONSIGNY",
+        "photo": "../img/consigny.jpg",
+        "xUrl": "https://twitter.com/ncsgy",
+        "role": "Lead",
+        "tagline": "Privacy in digital wallets visionary"
+      },
+      {
+        "name": "AYA MIYAGUCHI",
+        "photo": "../img/aya.jpg",
+        "xUrl": "https://x.com/AyaMiyagotchi",
+        "role": "President",
+        "tagline": "Steward of Ethereum's long-term ecosystem vision"
+      }
+    ],
+    "descriptionFull": "The nonprofit stewarding Ethereum protocol research and development, funding the teams and researchers pushing scalability, cryptography, and privacy tech across the ecosystem."
+  },
+  {
+    "slug": "flashbots",
+    "name": "Flashbots",
+    "orgUrl": "https://www.flashbots.net",
+    "icon": "https://www.google.com/s2/favicons?sz=128&domain=flashbots.net",
+    "curated": true,
+    "description": "R&D org mitigating MEV harms on Ethereum with fairer, more private transaction infrastructure.",
+    "direction": [
+      "Protocol & Research",
+      "Cryptography & ZK"
+    ],
+    "members": [
+      {
+        "name": "AHMED GHAPPOUR",
+        "photo": "../img/ahmedghappour.png",
+        "xUrl": "https://twitter.com/ghappour",
+        "role": "GC",
+        "tagline": "Engineer turned digital rights lawyer"
+      },
+      {
+        "name": "QUINTUS",
+        "photo": "../img/quintus.jpg",
+        "xUrl": "https://x.com/0xQuintus",
+        "role": "Lead",
+        "tagline": "Applied researcher exploring cryptography beyond the protocol layer"
+      }
+    ],
+    "descriptionFull": "A research and development organization mitigating the harms of MEV on Ethereum, building infrastructure like MEV-Boost and encrypted mempools for a fairer, more private transaction supply chain."
+  },
+  {
+    "slug": "nym",
+    "name": "Nym",
+    "orgUrl": "http://nym.com",
+    "icon": "https://www.google.com/s2/favicons?sz=128&domain=nym.com",
+    "curated": true,
+    "description": "Mixnet-based privacy infrastructure hiding metadata for anonymous VPN and messaging.",
+    "direction": [
+      "Networking & Mixnets",
+      "Cryptography & ZK"
+    ],
+    "members": [
+      {
+        "name": "HARRY HALPIN",
+        "photo": "../img/harryhalping.jog.webp",
+        "xUrl": "https://x.com/harryhalpin",
+        "role": "CEO",
+        "tagline": "Experienced activist bridging network-level privacy & practical VPN"
+      },
+      {
+        "name": "MAX HAMPSHIRE",
+        "photo": "../img/max-hampshire.jpg",
+        "xUrl": "https://x.com/_wjth",
+        "role": "Lead",
+        "tagline": "Privacy engineer focused on mixnets and metadata resistance"
+      }
+    ],
+    "descriptionFull": "A mixnet-based privacy infrastructure network that hides metadata — not just content — powering anonymous VPN and messaging layers resistant to network-level surveillance."
+  },
+  {
+    "slug": "railgun",
+    "name": "Railgun",
+    "orgUrl": "https://railgun.org/",
+    "icon": "https://www.google.com/s2/favicons?sz=128&domain=railgun.org",
+    "curated": true,
+    "description": "Privacy protocol enabling shielded, private DeFi transactions on EVM chains.",
+    "direction": [
+      "Cryptography & ZK",
+      "Wallets & Payments"
+    ],
+    "members": [
+      {
+        "name": "ALAN SCOTT",
+        "photo": "../img/alan.png",
+        "xUrl": "https://x.com/tsu_kareta",
+        "role": "Lead",
+        "tagline": "Privacy engineer advancing confidential Ethereum transactions"
+      },
+      {
+        "name": "KIERAN MESQUITA",
+        "photo": "../img/kieran.png",
+        "xUrl": "https://x.com/mesquka",
+        "role": "contributor",
+        "tagline": "Applied cryptographer serving millions of people"
+      }
+    ],
+    "descriptionFull": "A privacy protocol for EVM chains that lets users shield balances and transact privately in DeFi using zk-SNARKs, without leaving the smart contracts they already use."
+  },
+  {
+    "slug": "tor-project",
+    "name": "Tor Project",
+    "orgUrl": "https://torproject.org",
+    "icon": "https://www.google.com/s2/favicons?sz=128&domain=torproject.org",
+    "curated": true,
+    "description": "Free, open-source onion-routing network for anonymous browsing and censorship circumvention.",
+    "direction": [
+      "Networking & Mixnets",
+      "Digital Rights & Advocacy"
+    ],
+    "members": [
+      {
+        "name": "ISABELA FERNANDES",
+        "photo": "../img/fernandes.jpeg",
+        "xUrl": "https://x.com/Isa",
+        "role": "Executive Director",
+        "tagline": "Free & anonymous software advocate"
+      },
+      {
+        "name": "ROGER DINGLEDINE",
+        "photo": "../img/roger.png",
+        "xUrl": "https://x.com/RogerDingledine",
+        "role": "Lead",
+        "tagline": "Co-creator of Tor and pioneer of anonymous communications"
+      }
+    ],
+    "descriptionFull": "The nonprofit behind Tor, the free and open-source onion-routing network that lets millions of people browse and communicate anonymously and route around censorship."
+  },
+  {
+    "slug": "aragon",
+    "name": "Aragon",
+    "orgUrl": "https://aragon.org",
+    "icon": "https://www.google.com/s2/favicons?sz=128&domain=aragon.org",
+    "curated": true,
+    "description": "Toolkit for creating and running DAOs with on-chain governance primitives.",
+    "direction": [
+      "Governance & Public Goods",
+      "Protocol & Research"
+    ],
+    "members": [
+      {
+        "name": "LEUTS",
+        "photo": "../img/leuts-aragon.jpeg",
+        "xUrl": "https://x.com/A_Leutenegger",
+        "role": "Lead",
+        "tagline": "Governance innovator focused on resilient decentralized organizations"
+      }
+    ],
+    "descriptionFull": "A platform and toolkit for creating and running DAOs, giving communities the governance primitives to coordinate and manage shared resources without centralized control."
+  },
+  {
+    "slug": "aztec",
+    "name": "Aztec",
+    "orgUrl": "https://aztec.network/",
+    "icon": "https://www.google.com/s2/favicons?sz=128&domain=aztec.network",
+    "curated": true,
+    "description": "A privacy-focused zero-knowledge rollup enabling confidential smart contracts on Ethereum.",
+    "direction": [
+      "Cryptography & ZK",
+      "Protocol & Research"
+    ],
+    "members": [
+      {
+        "name": "ARNAUD SCHENK",
+        "photo": "../img/Arnaud Schenk.png",
+        "xUrl": "https://x.com/Arnaudschenk",
+        "role": "Co-Founder",
+        "tagline": "Helping protocols & institutions adopt ZK-tech"
+      }
+    ],
+    "descriptionFull": "A privacy-focused zero-knowledge rollup on Ethereum, using zk-SNARKs to enable confidential smart contracts and transactions at L2 scale."
+  },
+  {
+    "slug": "brave",
+    "name": "Brave",
+    "orgUrl": "http://brave.com",
+    "icon": "https://www.google.com/s2/favicons?sz=128&domain=brave.com",
+    "curated": true,
+    "description": "A privacy-first browser that blocks ads and trackers by default.",
+    "direction": [
+      "Browsers & Apps",
+      "Digital Rights & Advocacy"
+    ],
+    "members": [
+      {
+        "name": "KYLE DEN HARTOG",
+        "photo": "../img/kyledenhartog.jpg",
+        "xUrl": "https://x.com/PryvitKyle",
+        "role": "Staff Cryptographic Security Engineer",
+        "tagline": "Researcher blending traditional & innovative tech"
+      }
+    ],
+    "descriptionFull": "A privacy-first web browser built on Chromium that blocks ads and trackers by default, paired with a rewards system that puts users back in control of their attention and data."
+  },
+  {
+    "slug": "coin-center",
+    "name": "Coin Center",
+    "orgUrl": "https://coincenter.org",
+    "icon": "https://www.google.com/s2/favicons?sz=128&domain=coincenter.org",
+    "curated": true,
+    "description": "Independent nonprofit policy research and advocacy for open blockchain networks.",
+    "direction": [
+      "Legal & Policy",
+      "Digital Rights & Advocacy"
+    ],
+    "members": [
+      {
+        "name": "PETER VAN VALKENBURGH",
+        "photo": "../img/valkenburgh.jpg",
+        "xUrl": "https://twitter.com/valkenburgh",
+        "role": "Executive Director",
+        "tagline": "Advocate focused on the public policy on decentralized computing"
+      }
+    ],
+    "descriptionFull": "An independent nonprofit research and advocacy center focused on public policy for cryptocurrency and open blockchain networks, defending the right to build and use them."
+  },
+  {
+    "slug": "electronic-frontier-foundation",
+    "name": "Electronic Frontier Foundation",
+    "orgUrl": "https://www.eff.org/",
+    "icon": "https://www.google.com/s2/favicons?sz=128&domain=eff.org",
+    "curated": true,
+    "description": "Nonprofit defending civil liberties in the digital world since 1990.",
+    "direction": [
+      "Digital Rights & Advocacy",
+      "Legal & Policy"
+    ],
+    "members": [
+      {
+        "name": "EVA GALPERIN",
+        "photo": "../img/evagalperin.jpg",
+        "xUrl": "https://x.com/evacide",
+        "role": "Founder",
+        "tagline": "Visionary behind alternative tech ecosystem"
+      }
+    ],
+    "descriptionFull": "The leading nonprofit defending civil liberties in the digital world since 1990 — litigating, lobbying, and building tools for free speech, encryption, and privacy rights."
+  },
+  {
+    "slug": "filecoin-foundation",
+    "name": "Filecoin Foundation",
+    "orgUrl": "https://fil.org",
+    "icon": "https://www.google.com/s2/favicons?sz=128&domain=fil.org",
+    "curated": true,
+    "description": "Nonprofit growing the Filecoin decentralized storage ecosystem.",
+    "direction": [
+      "Storage & Infra",
+      "Governance & Public Goods"
+    ],
+    "members": [
+      {
+        "name": "WILL SCOTT",
+        "photo": "../img/willscott.jpeg",
+        "xUrl": "https://x.com/willscott",
+        "role": "Adoption",
+        "tagline": "Global prime hacktivist"
+      }
+    ],
+    "descriptionFull": "The nonprofit supporting the Filecoin network and its ecosystem of builders, growing decentralized storage as public infrastructure for the open web."
+  },
+  {
+    "slug": "hopr",
+    "name": "HOPR",
+    "orgUrl": "https://hoprnet.org/",
+    "icon": "https://www.google.com/s2/favicons?sz=128&domain=hoprnet.org",
+    "curated": true,
+    "description": "Incentivized mixnet protocol that strips metadata from data in transit.",
+    "direction": [
+      "Networking & Mixnets",
+      "Cryptography & ZK"
+    ],
+    "members": [
+      {
+        "name": "SEBASTIAN BüRGEL",
+        "photo": "../img/sebastian.png",
+        "xUrl": "https://x.com/SCBuergel",
+        "role": "Lead",
+        "tagline": "Pioneer of incentivized mixnet infrastructure"
+      }
+    ],
+    "descriptionFull": "An incentivized mixnet protocol that routes data through relay nodes to strip away metadata, rewarding node operators for providing network-level privacy."
+  },
+  {
+    "slug": "metamask",
+    "name": "MetaMask",
+    "orgUrl": "https://metamask.io",
+    "icon": "https://www.google.com/s2/favicons?sz=128&domain=metamask.io",
+    "curated": true,
+    "description": "The most widely used self-custodial Ethereum wallet and gateway to the dapp ecosystem.",
+    "direction": [
+      "Wallets & Payments",
+      "Browsers & Apps"
+    ],
+    "members": [
+      {
+        "name": "FRANCESCO ANDREOLI",
+        "photo": "../img/francesco.andreoli.webp",
+        "xUrl": "https://x.com/francescoswiss",
+        "role": "DevRel",
+        "tagline": "Helping protocols & institutions adopt ZK-tech"
+      }
+    ],
+    "descriptionFull": "The most widely used self-custodial Ethereum wallet, giving anyone a browser extension or mobile app to hold keys, sign transactions, and access the dapp ecosystem."
+  },
+  {
+    "slug": "protocol-labs",
+    "name": "Protocol Labs",
+    "orgUrl": "https://www.protocol.ai/",
+    "icon": "https://www.google.com/s2/favicons?sz=128&domain=protocol.ai",
+    "curated": true,
+    "description": "R&D lab behind IPFS, Filecoin, and libp2p for a decentralized internet.",
+    "direction": [
+      "Storage & Infra",
+      "Protocol & Research"
+    ],
+    "members": [
+      {
+        "name": "JUAN BENET",
+        "photo": "../img/benet.avif",
+        "xUrl": "https://x.com/juanbenet",
+        "role": "Lead",
+        "tagline": "Inventor of decentralized storage and network infrastructure"
+      }
+    ],
+    "descriptionFull": "The R&D lab behind IPFS, Filecoin, and libp2p — building the open protocols and networks for a decentralized, content-addressed internet."
+  },
+  {
+    "slug": "swarm",
+    "name": "Swarm",
+    "orgUrl": "https://ethswarm.org",
+    "icon": "https://www.google.com/s2/favicons?sz=128&domain=ethswarm.org",
+    "curated": true,
+    "description": "Decentralized storage and communication network for the self-sovereign web.",
+    "direction": [
+      "Storage & Infra",
+      "Networking & Mixnets"
+    ],
+    "members": [
+      {
+        "name": "VIKTOR TRÓN",
+        "photo": "../img/tron.jpg",
+        "xUrl": "https://x.com/zeligf",
+        "role": "Founder",
+        "tagline": "Visionary behind distributed tech"
+      }
+    ],
+    "descriptionFull": "A decentralized storage and communication network for the self-sovereign web, part of the wider Ethereum ecosystem’s push for censorship-resistant infrastructure."
+  },
+  {
+    "slug": "ethereum-foundation-iptf",
+    "name": "Ethereum Foundation & IPTF",
+    "orgUrl": "https://ethereum.foundation",
+    "icon": "https://www.google.com/s2/favicons?sz=128&domain=ethereum.foundation",
+    "curated": false,
+    "description": "Privacy researcher connecting Ethereum and human rights communities.",
+    "direction": [
+      "Legal & Policy",
+      "Messaging & Social",
+      "Protocol & Research"
+    ],
+    "members": [
+      {
+        "name": "OSKARTH",
+        "photo": "../img/oskarth.png",
+        "xUrl": "https://x.com/oskarth",
+        "role": "Lead",
+        "tagline": "Privacy researcher connecting Ethereum and human rights communities"
+      },
+      {
+        "name": "KEVIN JONES",
+        "photo": "../img/Kevin Jones.jpg",
+        "xUrl": "https://x.com/cryptomastery_",
+        "role": "Lead",
+        "tagline": "Messaging and privacy advocate within Ethereum's public interest ecosystem"
+      },
+      {
+        "name": "NIKOLINE ARNS",
+        "photo": "../img/nikoline.png",
+        "xUrl": "https://x.com/nikoline_nik",
+        "role": "Lead",
+        "tagline": "Public goods organizer connecting privacy and digital rights movements"
+      }
+    ],
+    "descriptionFull": "Privacy researcher connecting Ethereum and human rights communities. Messaging and privacy advocate within Ethereum's public interest ecosystem. Public goods organizer connecting privacy and digital rights movements."
+  },
+  {
+    "slug": "logos",
+    "name": "Logos",
+    "orgUrl": "https://logos.co",
+    "icon": "https://www.google.com/s2/favicons?sz=128&domain=logos.co",
+    "curated": false,
+    "description": "Mixnets visionary.",
+    "direction": [
+      "Protocol & Research",
+      "Cryptography & ZK",
+      "Digital Rights & Advocacy"
+    ],
+    "members": [
+      {
+        "name": "VACLAV PAVLIN",
+        "photo": "../img/vaclav-pavlin.jpg",
+        "xUrl": "https://x.com/vpavlin",
+        "role": "VP of Technology",
+        "tagline": "Mixnets visionary"
+      },
+      {
+        "name": "JARRAD HOPE",
+        "photo": "../img/jarradhope.png",
+        "xUrl": "https://x.com/jarradhope_",
+        "role": "Lead",
+        "tagline": "Architect of censorship-resistant network infrastructure"
+      },
+      {
+        "name": "KRIS IS",
+        "photo": "../img/kris.png",
+        "xUrl": "https://x.com/krrisis",
+        "role": "Lead",
+        "tagline": "Advocate for digital autonomy and internet freedom"
+      }
+    ],
+    "descriptionFull": "Mixnets visionary. Architect of censorship-resistant network infrastructure. Advocate for digital autonomy and internet freedom."
+  },
+  {
+    "slug": "dappnode",
+    "name": "Dappnode",
+    "orgUrl": "https://dappnode.com",
+    "icon": "https://www.google.com/s2/favicons?sz=128&domain=dappnode.com",
+    "curated": false,
+    "description": "Making self-hosted infrastructure accessible to everyone.",
+    "direction": [
+      "Digital Rights & Advocacy",
+      "Storage & Infra",
+      "Protocol & Research"
+    ],
+    "members": [
+      {
+        "name": "POL LANSKI",
+        "photo": "../img/lanski.jpeg",
+        "xUrl": "https://x.com/Pol_Lanski",
+        "role": "Lead",
+        "tagline": "Making self-hosted infrastructure accessible to everyone"
+      },
+      {
+        "name": "PAUL DYLAN-ENNIS",
+        "photo": "../img/paul-dylan-ennis.jpg",
+        "xUrl": "https://x.com/Pol_Lanski",
+        "role": "Lead",
+        "tagline": "Scholar documenting the social evolution of crypto communities"
+      }
+    ],
+    "descriptionFull": "Making self-hosted infrastructure accessible to everyone. Scholar documenting the social evolution of crypto communities."
+  },
+  {
+    "slug": "fileverse",
+    "name": "Fileverse",
+    "orgUrl": "https://fileverse.io/",
+    "icon": "https://www.google.com/s2/favicons?sz=128&domain=fileverse.io",
+    "curated": false,
+    "description": "Tech visionary challenging Google Suite.",
+    "direction": [
+      "Protocol & Research",
+      "Cryptography & ZK",
+      "Browsers & Apps"
+    ],
+    "members": [
+      {
+        "name": "VIJAY KRISHNAVANSHI",
+        "photo": "../img/vijay-krishnavanshi.jpeg",
+        "xUrl": "https://x.com/0x6b8",
+        "role": "Co-Founder",
+        "tagline": "Tech visionary challenging Google Suite"
+      },
+      {
+        "name": "MIROYATO",
+        "photo": "../img/andreas.png",
+        "xUrl": "https://x.com/miroyato",
+        "role": "Co-founder",
+        "tagline": "Academic turned practical privacy tech"
+      }
+    ],
+    "descriptionFull": "Tech visionary challenging Google Suite. Academic turned practical privacy tech."
+  },
+  {
+    "slug": "human-tech",
+    "name": "Human Tech",
+    "orgUrl": "https://human.tech",
+    "icon": "https://www.google.com/s2/favicons?sz=128&domain=human.tech",
+    "curated": false,
+    "description": "Digital identity advocate advancing human-centered credentials.",
+    "direction": [
+      "Identity & Credentials",
+      "Digital Rights & Advocacy"
+    ],
+    "members": [
+      {
+        "name": "NANAK NIHAL KHALSA",
+        "photo": "../img/Nanak-Nihal-Khalsa.jpg",
+        "xUrl": "https://x.com/NanakNihal",
+        "role": "Lead",
+        "tagline": "Digital identity advocate advancing human-centered credentials"
+      },
+      {
+        "name": "SHADY EL DAMATY",
+        "photo": "../img/shady.jpeg",
+        "xUrl": "https://x.com/hebbianloop",
+        "role": "CEO",
+        "tagline": "Digital rights activists delivering identity for the internet age"
+      }
+    ],
+    "descriptionFull": "Digital identity advocate advancing human-centered credentials. Digital rights activists delivering identity for the internet age."
+  },
+  {
+    "slug": "ideal",
+    "name": "Ideal",
+    "orgUrl": "https://ideal.group",
+    "icon": "https://www.google.com/s2/favicons?sz=128&domain=ideal.group",
+    "curated": false,
+    "description": "Helping protocols & institutions adopt ZK-tech.",
+    "direction": [
+      "Cryptography & ZK",
+      "Identity & Credentials",
+      "Protocol & Research"
+    ],
+    "members": [
+      {
+        "name": "YING TONG LAI",
+        "photo": "../img/yingtonglai2.jpg",
+        "xUrl": "https://twitter.com/therealyingtong",
+        "role": "Applied Cryptographer",
+        "tagline": "Helping protocols & institutions adopt ZK-tech"
+      },
+      {
+        "name": "LIAM EAGAN",
+        "photo": "../img/LIAM-EAGAN.webp",
+        "xUrl": "https://x.com/liameagen",
+        "role": "Applied Cryptographer",
+        "tagline": "Helping protocols & institutions adopt ZK-tech"
+      }
+    ],
+    "descriptionFull": "Helping protocols & institutions adopt ZK-tech."
+  },
+  {
+    "slug": "privacy-stewards-of-ethereum",
+    "name": "Privacy Stewards of Ethereum",
+    "orgUrl": "http://pse.dev",
+    "icon": "https://www.google.com/s2/favicons?sz=128&domain=pse.dev",
+    "curated": false,
+    "description": "Decentralised privacy adoption lead.",
+    "direction": [
+      "Cryptography & ZK",
+      "Identity & Credentials",
+      "Governance & Public Goods"
+    ],
+    "members": [
+      {
+        "name": "ANDY GUZMAN",
+        "photo": "../img/guzman.jpg",
+        "xUrl": "https://x.com/AndyGuzmanEth",
+        "role": "Head",
+        "tagline": "Decentralised privacy adoption lead"
+      },
+      {
+        "name": "JOHN GUILDING",
+        "photo": "../img/john.jpg",
+        "xUrl": "https://x.com/john_guilding",
+        "role": "Lead",
+        "tagline": "Bringing privacy technologies into real-world governance systems"
+      }
+    ],
+    "descriptionFull": "Decentralised privacy adoption lead. Bringing privacy technologies into real-world governance systems."
+  },
+  {
+    "slug": "1kx",
+    "name": "1kx",
+    "orgUrl": "https://1kx.capital",
+    "icon": "https://www.google.com/s2/favicons?sz=128&domain=1kx.capital",
+    "curated": false,
+    "description": "Helping protocols & institutions adopt ZK-tech.",
+    "direction": [
+      "Governance & Public Goods"
+    ],
+    "members": [
+      {
+        "name": "WEI DAI",
+        "photo": "../img/wei-dai.webp",
+        "xUrl": "https://x.com/_weidai",
+        "role": "Research Partner",
+        "tagline": "Helping protocols & institutions adopt ZK-tech"
+      }
+    ],
+    "descriptionFull": "Helping protocols & institutions adopt ZK-tech."
+  },
+  {
+    "slug": "alpeh-v",
+    "name": "alpeh_v",
+    "orgUrl": "https://x.com/alpeh_v",
+    "icon": "",
+    "curated": false,
+    "description": "Independent engineer advancing privacy-first infrastructure.",
+    "direction": [
+      "Protocol & Research"
+    ],
+    "members": [
+      {
+        "name": "alpeh_v",
+        "photo": "../img/alpeh.jpg",
+        "xUrl": "https://x.com/alpeh_v",
+        "role": "Lead",
+        "tagline": "Independent engineer advancing privacy-first infrastructure"
+      }
+    ],
+    "descriptionFull": "Independent engineer advancing privacy-first infrastructure."
+  },
+  {
+    "slug": "armada",
+    "name": "Armada",
+    "orgUrl": "https://armada.wtf/",
+    "icon": "https://www.google.com/s2/favicons?sz=128&domain=armada.wtf",
+    "curated": false,
+    "description": "Ethereum educator focused on resilient validator infrastructure.",
+    "direction": [
+      "Browsers & Apps"
+    ],
+    "members": [
+      {
+        "name": "GAVIN BIRCH",
+        "photo": "../img/gavinbirch.png",
+        "xUrl": "https://x.com/Ether_Gavin",
+        "role": "Lead",
+        "tagline": "Ethereum educator focused on resilient validator infrastructure"
+      }
+    ],
+    "descriptionFull": "Ethereum educator focused on resilient validator infrastructure."
+  },
+  {
+    "slug": "bread-coop",
+    "name": "Bread Coop",
+    "orgUrl": "https://bread.coop",
+    "icon": "https://www.google.com/s2/favicons?sz=128&domain=bread.coop",
+    "curated": false,
+    "description": "Cooperative economy advocate reimagining ownership online.",
+    "direction": [
+      "Governance & Public Goods"
+    ],
+    "members": [
+      {
+        "name": "JOSH DAVILA",
+        "photo": "../img/josh-davila.png",
+        "xUrl": "https://x.com/TBSocialist",
+        "role": "Lead",
+        "tagline": "Cooperative economy advocate reimagining ownership online"
+      }
+    ],
+    "descriptionFull": "Cooperative economy advocate reimagining ownership online."
+  },
+  {
+    "slug": "cake-wallet",
+    "name": "Cake Wallet",
+    "orgUrl": "cakewallet.com",
+    "icon": "https://www.google.com/s2/favicons?sz=128&domain=cakewallet.com",
+    "curated": false,
+    "description": "Self-custody educator championing everyday financial privacy.",
+    "direction": [
+      "Cryptography & ZK",
+      "Wallets & Payments"
+    ],
+    "members": [
+      {
+        "name": "SETH FOR PRIVACY",
+        "photo": "../img/sethforprivacy.jpg",
+        "xUrl": "https://x.com/sethforprivacy",
+        "role": "Lead",
+        "tagline": "Self-custody educator championing everyday financial privacy"
+      }
+    ],
+    "descriptionFull": "Self-custody educator championing everyday financial privacy."
+  },
+  {
+    "slug": "circles",
+    "name": "Circles",
+    "orgUrl": "https://x.com/CirclesUBI",
+    "icon": "",
+    "curated": false,
+    "description": "Researching universal basic income through decentralized networks.",
+    "direction": [
+      "Digital Rights & Advocacy",
+      "Cryptography & ZK",
+      "Protocol & Research"
+    ],
+    "members": [
+      {
+        "name": "JULIO LINARES",
+        "photo": "../img/julio.png",
+        "xUrl": "https://x.com/Julio_Linares_",
+        "role": "Lead",
+        "tagline": "Researching universal basic income through decentralized networks"
+      }
+    ],
+    "descriptionFull": "Researching universal basic income through decentralized networks."
+  },
+  {
+    "slug": "consensys-diligence",
+    "name": "Consensys Diligence",
+    "orgUrl": "https://diligence.security/",
+    "icon": "https://www.google.com/s2/favicons?sz=128&domain=diligence.security",
+    "curated": false,
+    "description": "Smart contract auditor securing Ethereum's critical infrastructure.",
+    "direction": [
+      "Security & Auditing"
+    ],
+    "members": [
+      {
+        "name": "TOBIAS VOGEL",
+        "photo": "../img/tobias.png",
+        "xUrl": "https://www.linkedin.com/in/tobias-vogel-66545b100/",
+        "role": "Lead",
+        "tagline": "Smart contract auditor securing Ethereum's critical infrastructure"
+      }
+    ],
+    "descriptionFull": "Smart contract auditor securing Ethereum's critical infrastructure."
+  },
+  {
+    "slug": "darkfi",
+    "name": "DarkFi",
+    "orgUrl": "https://x.com/DarkFiSquad",
+    "icon": "",
+    "curated": false,
+    "description": "Visionary hacktivist.",
+    "direction": [
+      "Protocol & Research"
+    ],
+    "members": [
+      {
+        "name": "AMIR TAAKI",
+        "photo": "../img/taaki.jpg",
+        "xUrl": "https://x.com/lunardragon420",
+        "role": "Founder",
+        "tagline": "Visionary hacktivist"
+      }
+    ],
+    "descriptionFull": "Visionary hacktivist."
+  },
+  {
+    "slug": "dweb",
+    "name": "Dweb",
+    "orgUrl": "https://getdweb.net",
+    "icon": "https://www.google.com/s2/favicons?sz=128&domain=getdweb.net",
+    "curated": false,
+    "description": "Visionary behind alternative tech ecosystem.",
+    "direction": [
+      "Governance & Public Goods",
+      "Digital Rights & Advocacy"
+    ],
+    "members": [
+      {
+        "name": "BETH MCCARTHY",
+        "photo": "../img/beth mccarthy.jpg",
+        "xUrl": "https://x.com/ontologymachine",
+        "role": "Facilitator",
+        "tagline": "Visionary behind alternative tech ecosystem"
+      }
+    ],
+    "descriptionFull": "Visionary behind alternative tech ecosystem."
+  },
+  {
+    "slug": "dyne-org",
+    "name": "Dyne.org",
+    "orgUrl": "https://dyne.org",
+    "icon": "https://www.google.com/s2/favicons?sz=128&domain=dyne.org",
+    "curated": false,
+    "description": "Long-lasting cryptographer & hacktivist.",
+    "direction": [
+      "Cryptography & ZK"
+    ],
+    "members": [
+      {
+        "name": "DENIS JAROMIL ROJO",
+        "photo": "../img/jaromil.jpg",
+        "xUrl": "https://x.com/jaromil",
+        "role": "Founder",
+        "tagline": "Long-lasting cryptographer & hacktivist"
+      }
+    ],
+    "descriptionFull": "Long-lasting cryptographer & hacktivist."
+  },
+  {
+    "slug": "ethereum-foundation-bordel",
+    "name": "Ethereum Foundation & BORDEL",
+    "orgUrl": "https://ethereum.foundation",
+    "icon": "https://www.google.com/s2/favicons?sz=128&domain=ethereum.foundation",
+    "curated": false,
+    "description": "FOSS advocate.",
+    "direction": [
+      "Digital Rights & Advocacy",
+      "Protocol & Research"
+    ],
+    "members": [
+      {
+        "name": "MARIO HAVEL",
+        "photo": "../img/havel.jpg",
+        "xUrl": "https://x.com/TMIYChao",
+        "role": "Protocol Support",
+        "tagline": "FOSS advocate"
+      }
+    ],
+    "descriptionFull": "FOSS advocate."
+  },
+  {
+    "slug": "ethereum-governance-ai",
+    "name": "Ethereum Governance AI",
+    "orgUrl": "https://x.com/EthereumGovAI",
+    "icon": "",
+    "curated": false,
+    "description": "Researcher applying AI to decentralized governance systems.",
+    "direction": [
+      "Governance & Public Goods"
+    ],
+    "members": [
+      {
+        "name": "TANISHA KATARA",
+        "photo": "../img/tanisha.jpg",
+        "xUrl": "https://x.com/governingweb3",
+        "role": "Lead",
+        "tagline": "Researcher applying AI to decentralized governance systems"
+      }
+    ],
+    "descriptionFull": "Researcher applying AI to decentralized governance systems."
+  },
+  {
+    "slug": "ethereum-institute",
+    "name": "Ethereum Institute",
+    "orgUrl": "https://ethereum.institute",
+    "icon": "https://www.google.com/s2/favicons?sz=128&domain=ethereum.institute",
+    "curated": false,
+    "description": "Policy researcher translating Ethereum for lawmakers and institutions.",
+    "direction": [
+      "Legal & Policy"
+    ],
+    "members": [
+      {
+        "name": "MARINA MARKEZIC",
+        "photo": "../img/Marina-Markezic.jpg",
+        "xUrl": "https://x.com/MarinaMarkezic",
+        "role": "Lead",
+        "tagline": "Policy researcher translating Ethereum for lawmakers and institutions"
+      }
+    ],
+    "descriptionFull": "Policy researcher translating Ethereum for lawmakers and institutions."
+  },
+  {
+    "slug": "ethereum-silviculture-society-harvard-allen-lab-fellow",
+    "name": "Ethereum Silviculture Society & Harvard Allen Lab Fellow",
+    "orgUrl": "https://x.com/mashbean",
+    "icon": "",
+    "curated": false,
+    "description": "Regenerative systems thinker cultivating public goods ecosystems.",
+    "direction": [
+      "Governance & Public Goods"
+    ],
+    "members": [
+      {
+        "name": "MASHBEAN",
+        "photo": "../img/mashbean.jpg",
+        "xUrl": "https://x.com/mashbean",
+        "role": "Lead",
+        "tagline": "Regenerative systems thinker cultivating public goods ecosystems"
+      }
+    ],
+    "descriptionFull": "Regenerative systems thinker cultivating public goods ecosystems."
+  },
+  {
+    "slug": "ethpanda",
+    "name": "ETHPanda",
+    "orgUrl": "https://ethpanda.org",
+    "icon": "https://www.google.com/s2/favicons?sz=128&domain=ethpanda.org",
+    "curated": false,
+    "description": "Visionary behind alternative tech ecosystem.",
+    "direction": [
+      "Cryptography & ZK"
+    ],
+    "members": [
+      {
+        "name": "BRUCE.ETH",
+        "photo": "../img/brucexu.eth.jpg",
+        "xUrl": "https://x.com/brucexu_eth",
+        "role": "Co-Founder",
+        "tagline": "Visionary behind alternative tech ecosystem"
+      }
+    ],
+    "descriptionFull": "Visionary behind alternative tech ecosystem."
+  },
+  {
+    "slug": "fairblock",
+    "name": "Fairblock",
+    "orgUrl": "https://www.fairblock.network/",
+    "icon": "https://www.google.com/s2/favicons?sz=128&domain=fairblock.network",
+    "curated": false,
+    "description": "Cryptography builder tackling fairness and transaction privacy.",
+    "direction": [
+      "Cryptography & ZK"
+    ],
+    "members": [
+      {
+        "name": "PIEMAN",
+        "photo": "../img/pieman.png",
+        "xUrl": "https://x.com/Pememoni",
+        "role": "Lead",
+        "tagline": "Cryptography builder tackling fairness and transaction privacy"
+      }
+    ],
+    "descriptionFull": "Cryptography builder tackling fairness and transaction privacy."
+  },
+  {
+    "slug": "fat-solutions",
+    "name": "FAT Solutions",
+    "orgUrl": "https://fatsolutions.xyz",
+    "icon": "https://www.google.com/s2/favicons?sz=128&domain=fatsolutions.xyz",
+    "curated": false,
+    "description": "Open-source engineer building privacy-enhancing Ethereum tools.",
+    "direction": [
+      "Protocol & Research"
+    ],
+    "members": [
+      {
+        "name": "PARSLEY",
+        "photo": "../img/Parsley.jpg",
+        "xUrl": "https://x.com/Parsley3D",
+        "role": "Lead",
+        "tagline": "Open-source engineer building privacy-enhancing Ethereum tools"
+      }
+    ],
+    "descriptionFull": "Open-source engineer building privacy-enhancing Ethereum tools."
+  },
+  {
+    "slug": "fatemeh-fannizadeh",
+    "name": "FATEMEH FANNIZADEH",
+    "orgUrl": "https://x.com/Fatalmeh",
+    "icon": "",
+    "curated": false,
+    "description": "Legal expert on decentralized computing & activism.",
+    "direction": [
+      "Legal & Policy",
+      "Digital Rights & Advocacy"
+    ],
+    "members": [
+      {
+        "name": "FATEMEH FANNIZADEH",
+        "photo": "../img/fatemeh.png",
+        "xUrl": "https://x.com/Fatalmeh",
+        "role": "Legal",
+        "tagline": "Legal expert on decentralized computing & activism"
+      }
+    ],
+    "descriptionFull": "Legal expert on decentralized computing & activism."
+  },
+  {
+    "slug": "fhenix",
+    "name": "Fhenix",
+    "orgUrl": "https://www.fhenix.io",
+    "icon": "https://www.google.com/s2/favicons?sz=128&domain=fhenix.io",
+    "curated": false,
+    "description": "Driving confidential computation toward mainstream adoption.",
+    "direction": [
+      "Cryptography & ZK",
+      "Digital Rights & Advocacy"
+    ],
+    "members": [
+      {
+        "name": "KATE STAPLETON",
+        "photo": "../img/kate-stapleton.png",
+        "xUrl": "https://x.com/kate_stapes",
+        "role": "Lead",
+        "tagline": "Driving confidential computation toward mainstream adoption"
+      }
+    ],
+    "descriptionFull": "Driving confidential computation toward mainstream adoption."
+  },
+  {
+    "slug": "filecoin",
+    "name": "Filecoin",
+    "orgUrl": "https://fil.org",
+    "icon": "https://www.google.com/s2/favicons?sz=128&domain=fil.org",
+    "curated": false,
+    "description": "Former Deputy Executive Director and General Counsel of EFF.",
+    "direction": [
+      "Digital Rights & Advocacy"
+    ],
+    "members": [
+      {
+        "name": "KURT OPSAHL",
+        "photo": "../img/kurtopsahl2.jpg",
+        "xUrl": "https://x.com/kurtopsahl",
+        "role": "Associate General Counsel for Cybersecurity and Civil Liberties Policy",
+        "tagline": "Former Deputy Executive Director and General Counsel of EFF"
+      }
+    ],
+    "descriptionFull": "Former Deputy Executive Director and General Counsel of EFF."
+  },
+  {
+    "slug": "filecoin-foundation-eff",
+    "name": "Filecoin Foundation, EFF",
+    "orgUrl": "https://fil.org",
+    "icon": "https://www.google.com/s2/favicons?sz=128&domain=fil.org",
+    "curated": false,
+    "description": "Former director of strategy at EFF.",
+    "direction": [
+      "Digital Rights & Advocacy"
+    ],
+    "members": [
+      {
+        "name": "DANNY O'BRIEN",
+        "photo": "../img/obrien.jpg",
+        "xUrl": "https://twitter.com/mala",
+        "role": "Senior Fellow",
+        "tagline": "Former director of strategy at EFF"
+      }
+    ],
+    "descriptionFull": "Former director of strategy at EFF."
+  },
+  {
+    "slug": "fluidkey",
+    "name": "Fluidkey",
+    "orgUrl": "https://www.fluidkey.com",
+    "icon": "https://www.google.com/s2/favicons?sz=128&domain=fluidkey.com",
+    "curated": false,
+    "description": "Stealth addresses advocate.",
+    "direction": [
+      "Cryptography & ZK",
+      "Protocol & Research"
+    ],
+    "members": [
+      {
+        "name": "ANTONIO SEVESO",
+        "photo": "../img/seveso.png",
+        "xUrl": "https://x.com/0xMeTony",
+        "role": "Co-founder",
+        "tagline": "Stealth addresses advocate"
+      }
+    ],
+    "descriptionFull": "Stealth addresses advocate."
+  },
+  {
+    "slug": "freedom-browser",
+    "name": "Freedom Browser",
+    "orgUrl": "https://freedombrowser.eth.limo",
+    "icon": "https://www.google.com/s2/favicons?sz=128&domain=freedombrowser.eth.limo",
+    "curated": false,
+    "description": "Lawyer building freedom-preserving tools for the sovereign web.",
+    "direction": [
+      "Browsers & Apps",
+      "Legal & Policy"
+    ],
+    "members": [
+      {
+        "name": "FLORIAN GLATZ",
+        "photo": "../img/florian-glatz.jpg",
+        "xUrl": "https://x.com/heckerhut",
+        "role": "Lead",
+        "tagline": "Lawyer building freedom-preserving tools for the sovereign web"
+      }
+    ],
+    "descriptionFull": "Lawyer building freedom-preserving tools for the sovereign web."
+  },
+  {
+    "slug": "freedom-of-the-press-foundation",
+    "name": "Freedom Of The Press Foundation",
+    "orgUrl": "https://freedom.press",
+    "icon": "https://www.google.com/s2/favicons?sz=128&domain=freedom.press",
+    "curated": false,
+    "description": "Security engineer advancing press freedom through open-source tools.",
+    "direction": [
+      "Digital Rights & Advocacy",
+      "Cryptography & ZK"
+    ],
+    "members": [
+      {
+        "name": "Dr. JENNIFER HELSBY",
+        "photo": "../img/redshiftzero.png",
+        "xUrl": "https://x.com/redshiftzero",
+        "role": "Lead",
+        "tagline": "Security engineer advancing press freedom through open-source tools"
+      }
+    ],
+    "descriptionFull": "Security engineer advancing press freedom through open-source tools."
+  },
+  {
+    "slug": "gcc",
+    "name": "GCC",
+    "orgUrl": "https://www.gccofficial.org",
+    "icon": "https://www.google.com/s2/favicons?sz=128&domain=gccofficial.org",
+    "curated": false,
+    "description": "Scaling Asian Public Goods Sector.",
+    "direction": [
+      "Governance & Public Goods"
+    ],
+    "members": [
+      {
+        "name": "HAZEL HU",
+        "photo": "../img/hazel-hu.jpg",
+        "xUrl": "https://x.com/0xHY2049",
+        "role": "Facilitator",
+        "tagline": "Scaling Asian Public Goods Sector"
+      }
+    ],
+    "descriptionFull": "Scaling Asian Public Goods Sector."
+  },
+  {
+    "slug": "infinite-garden",
+    "name": "Infinite Garden",
+    "orgUrl": "",
+    "icon": "",
+    "curated": false,
+    "description": "Digital rights meeting decentralised tech.",
+    "direction": [
+      "Digital Rights & Advocacy"
+    ],
+    "members": [
+      {
+        "name": "DANIEL KNOBELSDORF",
+        "photo": "../img/knobelsdorf.png",
+        "xUrl": "",
+        "role": "Lead",
+        "tagline": "Digital rights meeting decentralised tech"
+      }
+    ],
+    "descriptionFull": "Digital rights meeting decentralised tech."
+  },
+  {
+    "slug": "institute-of-free-technology",
+    "name": "Institute of Free Technology",
+    "orgUrl": "https://free.technology/",
+    "icon": "https://www.google.com/s2/favicons?sz=128&domain=free.technology",
+    "curated": false,
+    "description": "Builder of open technology beyond platform dependence.",
+    "direction": [
+      "Storage & Infra"
+    ],
+    "members": [
+      {
+        "name": "ALISHER",
+        "photo": "../img/alisher.png",
+        "xUrl": "https://x.com/alisher",
+        "role": "Lead",
+        "tagline": "Builder of open technology beyond platform dependence"
+      }
+    ],
+    "descriptionFull": "Builder of open technology beyond platform dependence."
+  },
+  {
+    "slug": "intmax",
+    "name": "INTMAX",
+    "orgUrl": "https://x.com/IntmaxIO",
+    "icon": "",
+    "curated": false,
+    "description": "Scaling Ethereum privacy through next-generation rollup design.",
+    "direction": [
+      "Protocol & Research"
+    ],
+    "members": [
+      {
+        "name": "HIOKI LEONA",
+        "photo": "../img/hiokileona.jpg",
+        "xUrl": "https://x.com/leo_hio",
+        "role": "Lead",
+        "tagline": "Scaling Ethereum privacy through next-generation rollup design"
+      }
+    ],
+    "descriptionFull": "Scaling Ethereum privacy through next-generation rollup design."
+  },
+  {
+    "slug": "jito-factory-labs",
+    "name": "Jito & Factory Labs",
+    "orgUrl": "https://x.com/jito_sol",
+    "icon": "",
+    "curated": false,
+    "description": "Governance researcher examining incentives and decentralized coordination.",
+    "direction": [
+      "Governance & Public Goods"
+    ],
+    "members": [
+      {
+        "name": "NICK ALMOND",
+        "photo": "../img/nick-almond.jpg",
+        "xUrl": "https://x.com/DrNickA",
+        "role": "Lead",
+        "tagline": "Governance researcher examining incentives and decentralized coordination"
+      }
+    ],
+    "descriptionFull": "Governance researcher examining incentives and decentralized coordination."
+  },
+  {
+    "slug": "ludlow-institute",
+    "name": "Ludlow Institute",
+    "orgUrl": "https://www.ludlowinstitute.org",
+    "icon": "https://www.google.com/s2/favicons?sz=128&domain=ludlowinstitute.org",
+    "curated": false,
+    "description": "Privacy educator making digital self-defense accessible.",
+    "direction": [
+      "Digital Rights & Advocacy"
+    ],
+    "members": [
+      {
+        "name": "NAOMI BROCKWELL",
+        "photo": "../img/naomibrockwell.jpg",
+        "xUrl": "https://x.com/naomibrockwell",
+        "role": "Lead",
+        "tagline": "Privacy educator making digital self-defense accessible"
+      }
+    ],
+    "descriptionFull": "Privacy educator making digital self-defense accessible."
+  },
+  {
+    "slug": "mask-network",
+    "name": "Mask Network",
+    "orgUrl": "https://www.mask.io/",
+    "icon": "https://www.google.com/s2/favicons?sz=128&domain=mask.io",
+    "curated": false,
+    "description": "Connecting privacy, identity, and social networking.",
+    "direction": [
+      "Messaging & Social"
+    ],
+    "members": [
+      {
+        "name": "SUJI JAN",
+        "photo": "../img/suji-yan.jpg",
+        "xUrl": "https://x.com/suji_yan",
+        "role": "Lead",
+        "tagline": "Connecting privacy, identity, and social networking"
+      }
+    ],
+    "descriptionFull": "Connecting privacy, identity, and social networking."
+  },
+  {
+    "slug": "mother-ai",
+    "name": "Mother AI",
+    "orgUrl": "https://www.hellomother.co.uk/",
+    "icon": "https://www.google.com/s2/favicons?sz=128&domain=hellomother.co.uk",
+    "curated": false,
+    "description": "Entrepreneur exploring alternatives to extractive digital platforms.",
+    "direction": [
+      "Digital Rights & Advocacy"
+    ],
+    "members": [
+      {
+        "name": "MANU ALZURU",
+        "photo": "../img/manualzuru.png",
+        "xUrl": "https://x.com/ManuAlzuru",
+        "role": "Lead",
+        "tagline": "Entrepreneur exploring alternatives to extractive digital platforms"
+      }
+    ],
+    "descriptionFull": "Entrepreneur exploring alternatives to extractive digital platforms."
+  },
+  {
+    "slug": "neverlocal",
+    "name": "NeverLocal",
+    "orgUrl": "https://neverlocal.com",
+    "icon": "https://www.google.com/s2/favicons?sz=128&domain=neverlocal.com",
+    "curated": false,
+    "description": "Researcher exploring post-quantum and privacy-preserving systems.",
+    "direction": [
+      "Protocol & Research",
+      "Cryptography & ZK"
+    ],
+    "members": [
+      {
+        "name": "STEFANO GOGIOSO",
+        "photo": "../img/stefano-gogioso-profile.jpg",
+        "xUrl": "https://x.com/StefanoGogioso",
+        "role": "Lead",
+        "tagline": "Researcher exploring post-quantum and privacy-preserving systems"
+      }
+    ],
+    "descriptionFull": "Researcher exploring post-quantum and privacy-preserving systems."
+  },
+  {
+    "slug": "palliora",
+    "name": "Palliora",
+    "orgUrl": "https://palliora.org/",
+    "icon": "https://www.google.com/s2/favicons?sz=128&domain=palliora.org",
+    "curated": false,
+    "description": "Researcher bringing rigorous privacy science to Web3.",
+    "direction": [
+      "Cryptography & ZK",
+      "Protocol & Research"
+    ],
+    "members": [
+      {
+        "name": "AMIT CHAUDHARY",
+        "photo": "../img/amitchaudhary.png",
+        "xUrl": "https://x.com/amitchax",
+        "role": "Lead",
+        "tagline": "Researcher bringing rigorous privacy science to Web3"
+      }
+    ],
+    "descriptionFull": "Researcher bringing rigorous privacy science to Web3."
+  },
+  {
+    "slug": "plexos-institute",
+    "name": "Plexos Institute",
+    "orgUrl": "https://www.plexosinstitute.org",
+    "icon": "https://www.google.com/s2/favicons?sz=128&domain=plexosinstitute.org",
+    "curated": false,
+    "description": "Governance strategist at the intersection of law and digital rights.",
+    "direction": [
+      "Governance & Public Goods",
+      "Legal & Policy"
+    ],
+    "members": [
+      {
+        "name": "CAMILA RIOJA",
+        "photo": "../img/camila-rioja.jpg",
+        "xUrl": "https://x.com/mila_rioja",
+        "role": "Lead",
+        "tagline": "Governance strategist at the intersection of law and digital rights"
+      }
+    ],
+    "descriptionFull": "Governance strategist at the intersection of law and digital rights."
+  },
+  {
+    "slug": "privacy-pools",
+    "name": "Privacy Pools",
+    "orgUrl": "https://privacypools.com/",
+    "icon": "https://www.google.com/s2/favicons?sz=128&domain=privacypools.com",
+    "curated": false,
+    "description": "Cryptographer designing compliant privacy for public blockchains.",
+    "direction": [
+      "Cryptography & ZK"
+    ],
+    "members": [
+      {
+        "name": "AMEEN SULEIMANI",
+        "photo": "../img/ameen.png",
+        "xUrl": "https://x.com/ameensol",
+        "role": "Lead",
+        "tagline": "Cryptographer designing compliant privacy for public blockchains"
+      }
+    ],
+    "descriptionFull": "Cryptographer designing compliant privacy for public blockchains."
+  },
+  {
+    "slug": "protocol-guild",
+    "name": "Protocol Guild",
+    "orgUrl": "https://www.protocolguild.org",
+    "icon": "https://www.google.com/s2/favicons?sz=128&domain=protocolguild.org",
+    "curated": false,
+    "description": "Long-term Ethereum contributor funding protocol sustainability.",
+    "direction": [
+      "Cryptography & ZK",
+      "Protocol & Research"
+    ],
+    "members": [
+      {
+        "name": "CHEEKY GORILLA",
+        "photo": "../img/Cheeky-gorilla.jpg",
+        "xUrl": "https://x.com/cheekygorilla0x",
+        "role": "Lead",
+        "tagline": "Long-term Ethereum contributor funding protocol sustainability"
+      }
+    ],
+    "descriptionFull": "Long-term Ethereum contributor funding protocol sustainability."
+  },
+  {
+    "slug": "radicle",
+    "name": "Radicle",
+    "orgUrl": "https://radicle.dev/",
+    "icon": "https://www.google.com/s2/favicons?sz=128&domain=radicle.dev",
+    "curated": false,
+    "description": "Building sovereign collaboration tools for open-source communities.",
+    "direction": [
+      "Governance & Public Goods"
+    ],
+    "members": [
+      {
+        "name": "ELEFTHERIOS",
+        "photo": "../img/eleftherios.png",
+        "xUrl": "https://x.com/lftherios",
+        "role": "Lead",
+        "tagline": "Building sovereign collaboration tools for open-source communities"
+      }
+    ],
+    "descriptionFull": "Building sovereign collaboration tools for open-source communities."
+  },
+  {
+    "slug": "rarimo",
+    "name": "Rarimo",
+    "orgUrl": "https://rarimo.com/",
+    "icon": "https://www.google.com/s2/favicons?sz=128&domain=rarimo.com",
+    "curated": false,
+    "description": "Identity innovator enabling borderless democratic participation.",
+    "direction": [
+      "Identity & Credentials",
+      "Governance & Public Goods",
+      "Digital Rights & Advocacy"
+    ],
+    "members": [
+      {
+        "name": "LASHA ANTADZE",
+        "photo": "../img/lasha.png",
+        "xUrl": "https://x.com/lashaantadze",
+        "role": "Lead",
+        "tagline": "Identity innovator enabling borderless democratic participation"
+      }
+    ],
+    "descriptionFull": "Identity innovator enabling borderless democratic participation."
+  },
+  {
+    "slug": "rotki",
+    "name": "Rotki",
+    "orgUrl": "https://rotki.com/",
+    "icon": "https://www.google.com/s2/favicons?sz=128&domain=rotki.com",
+    "curated": false,
+    "description": "Champion of financial transparency through open-source software.",
+    "direction": [
+      "Browsers & Apps",
+      "Governance & Public Goods"
+    ],
+    "members": [
+      {
+        "name": "LEFTERIS KARAPETSAS",
+        "photo": "../img/lefteris.png",
+        "xUrl": "https://x.com/LefterisJP",
+        "role": "Lead",
+        "tagline": "Champion of financial transparency through open-source software"
+      }
+    ],
+    "descriptionFull": "Champion of financial transparency through open-source software."
+  },
+  {
+    "slug": "sentinel-alliance",
+    "name": "Sentinel Alliance",
+    "orgUrl": "https://www.sentinelalliance.org/",
+    "icon": "https://www.google.com/s2/favicons?sz=128&domain=sentinelalliance.org",
+    "curated": false,
+    "description": "Defender of civil liberties in the digital age.",
+    "direction": [
+      "Digital Rights & Advocacy",
+      "Legal & Policy"
+    ],
+    "members": [
+      {
+        "name": "JOAN ARUS",
+        "photo": "../img/joan.jpg",
+        "xUrl": "https://x.com/Joan_Arus",
+        "role": "Lead",
+        "tagline": "Defender of civil liberties in the digital age"
+      }
+    ],
+    "descriptionFull": "Defender of civil liberties in the digital age."
+  },
+  {
+    "slug": "session",
+    "name": "Session",
+    "orgUrl": "https://getsession.org",
+    "icon": "https://www.google.com/s2/favicons?sz=128&domain=getsession.org",
+    "curated": false,
+    "description": "Decentralised messengers visionary.",
+    "direction": [
+      "Messaging & Social",
+      "Browsers & Apps"
+    ],
+    "members": [
+      {
+        "name": "CHRIS MCCABE",
+        "photo": "../img/chrismccabe.jpg",
+        "xUrl": "https://twitter.com/Cryptic_cm",
+        "role": "Co-founder",
+        "tagline": "Decentralised messengers visionary"
+      }
+    ],
+    "descriptionFull": "Decentralised messengers visionary."
+  },
+  {
+    "slug": "shutter-network",
+    "name": "Shutter Network",
+    "orgUrl": "https://linktr.ee/ShutterNetwork",
+    "icon": "https://www.google.com/s2/favicons?sz=128&domain=linktr.ee",
+    "curated": false,
+    "description": "Encrypted Mempools advocate.",
+    "direction": [
+      "Cryptography & ZK",
+      "Protocol & Research"
+    ],
+    "members": [
+      {
+        "name": "Loring Harkness",
+        "photo": "../img/loring.jpg",
+        "xUrl": "https://x.com/LoringHarkness",
+        "role": "Lead",
+        "tagline": "Encrypted Mempools advocate"
+      }
+    ],
+    "descriptionFull": "Encrypted Mempools advocate."
+  },
+  {
+    "slug": "sovright",
+    "name": "Sovright",
+    "orgUrl": "https://sovright.com",
+    "icon": "https://www.google.com/s2/favicons?sz=128&domain=sovright.com",
+    "curated": false,
+    "description": "Open-hardware enthusiast.",
+    "direction": [
+      "Cryptography & ZK",
+      "Storage & Infra"
+    ],
+    "members": [
+      {
+        "name": "ml_sudo",
+        "photo": "../img/michelleLai.png",
+        "xUrl": "https://x.com/ml_sudo",
+        "role": "Lead",
+        "tagline": "Open-hardware enthusiast"
+      }
+    ],
+    "descriptionFull": "Open-hardware enthusiast."
+  },
+  {
+    "slug": "status",
+    "name": "Status",
+    "orgUrl": "",
+    "icon": "",
+    "curated": false,
+    "description": "Community strategist shaping private social coordination tools.",
+    "direction": [
+      "Messaging & Social"
+    ],
+    "members": [
+      {
+        "name": "CYP",
+        "photo": "../img/cyp.png",
+        "xUrl": "https://x.com/0xcyp",
+        "role": "Lead",
+        "tagline": "Community strategist shaping private social coordination tools"
+      }
+    ],
+    "descriptionFull": "Community strategist shaping private social coordination tools."
+  },
+  {
+    "slug": "strato",
+    "name": "Strato",
+    "orgUrl": "https://strato.nexus",
+    "icon": "https://www.google.com/s2/favicons?sz=128&domain=strato.nexus",
+    "curated": false,
+    "description": "Decentralisation veteran.",
+    "direction": [
+      "Digital Rights & Advocacy"
+    ],
+    "members": [
+      {
+        "name": "BOB SUMMERWILL",
+        "photo": "../img/bobsummerwill.png",
+        "xUrl": "https://x.com/BobSummerwill",
+        "role": "Head of Ecosystem",
+        "tagline": "Decentralisation veteran"
+      }
+    ],
+    "descriptionFull": "Decentralisation veteran."
+  },
+  {
+    "slug": "taceo",
+    "name": "Taceo",
+    "orgUrl": "https://taceo.io",
+    "icon": "https://www.google.com/s2/favicons?sz=128&domain=taceo.io",
+    "curated": false,
+    "description": "MPC researcher turning advanced cryptography into usable infrastructure.",
+    "direction": [
+      "Cryptography & ZK"
+    ],
+    "members": [
+      {
+        "name": "AIS CONNOLLY",
+        "photo": "../img/aisconnolly.jpg",
+        "xUrl": "https://x.com/aisconnolly",
+        "role": "Lead",
+        "tagline": "MPC researcher turning advanced cryptography into usable infrastructure"
+      }
+    ],
+    "descriptionFull": "MPC researcher turning advanced cryptography into usable infrastructure."
+  },
+  {
+    "slug": "teleport-computer",
+    "name": "Teleport Computer",
+    "orgUrl": "https://router.teleport.computer/",
+    "icon": "https://www.google.com/s2/favicons?sz=128&domain=router.teleport.computer",
+    "curated": false,
+    "description": "Academic cryptographer turning theory into deployed systems.",
+    "direction": [
+      "Cryptography & ZK",
+      "Protocol & Research"
+    ],
+    "members": [
+      {
+        "name": "ANDREW MILLER",
+        "photo": "../img/andrew-miller.jpg",
+        "xUrl": "https://x.com/socrates1024",
+        "role": "Lead",
+        "tagline": "Academic cryptographer turning theory into deployed systems"
+      }
+    ],
+    "descriptionFull": "Academic cryptographer turning theory into deployed systems."
+  },
+  {
+    "slug": "vocdoni",
+    "name": "Vocdoni",
+    "orgUrl": "https://vocdoni.io/en",
+    "icon": "https://www.google.com/s2/favicons?sz=128&domain=vocdoni.io",
+    "curated": false,
+    "description": "Building verifiable digital voting for modern democracies.",
+    "direction": [
+      "Governance & Public Goods",
+      "Protocol & Research"
+    ],
+    "members": [
+      {
+        "name": "JORDI PINYANA",
+        "photo": "../img/pinyana.jpeg",
+        "xUrl": "https://x.com/jordipainan",
+        "role": "Lead",
+        "tagline": "Building verifiable digital voting for modern democracies"
+      }
+    ],
+    "descriptionFull": "Building verifiable digital voting for modern democracies."
+  },
+  {
+    "slug": "walletbeat",
+    "name": "Walletbeat",
+    "orgUrl": "https://walletbeat.eth.limo",
+    "icon": "https://www.google.com/s2/favicons?sz=128&domain=walletbeat.eth.limo",
+    "curated": false,
+    "description": "Wallet researcher focused on safer user experiences.",
+    "direction": [
+      "Wallets & Payments",
+      "Protocol & Research"
+    ],
+    "members": [
+      {
+        "name": "POLYMUTEX",
+        "photo": "../img/polymutex.jpg",
+        "xUrl": "https://x.com/polymutex",
+        "role": "Lead",
+        "tagline": "Wallet researcher focused on safer user experiences"
+      }
+    ],
+    "descriptionFull": "Wallet researcher focused on safer user experiences."
+  },
+  {
+    "slug": "warptoad",
+    "name": "Warptoad",
+    "orgUrl": "https://warptoad.org/",
+    "icon": "https://www.google.com/s2/favicons?sz=128&domain=warptoad.org",
+    "curated": false,
+    "description": "Builder of practical tools for privacy-first internet users.",
+    "direction": [
+      "Protocol & Research"
+    ],
+    "members": [
+      {
+        "name": "JIMJIM",
+        "photo": "../img/jimjim.png",
+        "xUrl": "https://x.com/jimjim_eth",
+        "role": "Lead",
+        "tagline": "Builder of practical tools for privacy-first internet users"
+      }
+    ],
+    "descriptionFull": "Builder of practical tools for privacy-first internet users."
+  },
+  {
+    "slug": "web3privacy-now",
+    "name": "Web3Privacy Now",
+    "orgUrl": "https://web3privacy.info",
+    "icon": "https://www.google.com/s2/favicons?sz=128&domain=web3privacy.info",
+    "curated": false,
+    "description": "Community builder growing the Web3 privacy movement.",
+    "direction": [
+      "Digital Rights & Advocacy"
+    ],
+    "members": [
+      {
+        "name": "PG",
+        "photo": "../img/pg.jpg",
+        "xUrl": "https://x.com/PG_CDG",
+        "role": "Lead",
+        "tagline": "Community builder growing the Web3 privacy movement"
+      }
+    ],
+    "descriptionFull": "Community builder growing the Web3 privacy movement."
+  },
+  {
+    "slug": "zisk",
+    "name": "Zisk",
+    "orgUrl": "http://zisk.technology",
+    "icon": "https://www.google.com/s2/favicons?sz=128&domain=zisk.technology",
+    "curated": false,
+    "description": "Catalan cryptographer targeted by Pegasus.",
+    "direction": [
+      "Digital Rights & Advocacy"
+    ],
+    "members": [
+      {
+        "name": "JORDI BAYLINA",
+        "photo": "../img/baylina.jpg",
+        "xUrl": "https://x.com/jbaylina",
+        "role": "Co-founder",
+        "tagline": "Catalan cryptographer targeted by Pegasus"
+      }
+    ],
+    "descriptionFull": "Catalan cryptographer targeted by Pegasus."
+  }
+]


### PR DESCRIPTION
Adds a new /projects page that groups the community into organization/project cards instead of individual people, so visitors can browse the privacy stack by team and by technology.

- projects/index.html: new page, styled to match /community. Each card shows an org icon (favicon via domain), name, up to 2 technology-direction badges (+N overflow), a short description, a "Read more" link opening a modal with the full description, full direction list and the complete team, and up to 3 team photo-tiles (+N overflow) on the card itself.
- projects/projects.json: 75 project entries generated by grouping community/comminity.json by organization. 15 well-known projects (Tor Project, EFF, Flashbots, MetaMask, Aztec, Ethereum Foundation, Brave, Nym, HOPR, Railgun, Protocol Labs, Filecoin Foundation, Coin Center, Aragon, Swarm) have hand-written short/full descriptions and curated technology tags (curated: true); the rest use tags derived from the existing "industry" field and a description built from member taglines as a placeholder (curated: false).
- Filter bar lets visitors filter cards by technology direction (Cryptography & ZK, Identity & Credentials, Wallets & Payments, Messaging & Social, Networking & Mixnets, Storage & Infra, Protocol & Research, Governance & Public Goods, Legal & Policy, Security & Auditing, Browsers & Apps, Digital Rights & Advocacy).
- index.html: add a "Projects" link to the desktop and mobile nav, right after "Community".

Layout is a fixed-height CSS grid (not masonry) so cards line up evenly regardless of team size, with mobile-specific tweaks (fewer badges/columns, min-width:0 fixes) to avoid horizontal overflow on narrow screens.